### PR TITLE
docs: add AI contribution policy tracking OpenSSF

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,10 @@ This can be done automatically by passing the `-s` flag to `git commit`:
 git commit -s -m "feat: add new CRS integration"
 ```
 
+## Use of AI Tools
+
+OSS-CRS tracks the [OpenSSF AI Contribution Policy](https://github.com/ossf/tac/pull/605) and adopts it as our policy for AI-assisted and AI-generated contributions. AI tools may be used to help prepare a contribution, but a human contributor must review and understand every change they submit; you are responsible for the correctness and quality of your contribution regardless of the tools used to produce it.
+
 ## Code of Conduct
 
 This project follows the [LF Projects Code of Conduct](https://lfprojects.org/policies/code-of-conduct/). Please report any unacceptable behavior to the TSC or the Series Manager.


### PR DESCRIPTION
Adopt the OpenSSF AI Contribution Policy (ossf/tac#605) as the project's policy for AI-assisted and AI-generated contributions, requiring human review of every submitted change.

Closes #216

## Summary

Adds a ## Use of AI Tools section to CONTRIBUTING.md that tracks and adopts the OpenSSF AI Contribution Policy (ossf/tac#605). Per the issue author's decision, OSS-CRS tracks the OpenSSF policy rather than authoring a bespoke one, since no incompatibility with OSS-CRS development was identified. The section states that AI-assisted contributions are acceptable but a human must review, understand, and remain responsible for every change. Implemented via the existing adopt-by-reference pattern already used by the ## Code of Conduct section.