### PR TITLE
Offline run images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ stricter subset of Keep a Changelog).
 
 ### Changed
 
+- `--offline` flag for all subcommands: disables git fetch
 - `libCRS` `apply_patch_build`: builder-side errors returned before a `rebuild_id` is assigned are now written to `<response_dir>/stderr.log` instead of being dropped. The public signature (`apply_patch_build(patch_path, response_dir, ...)`) and the positional shell form (`apply-patch-build <patch> <response_dir>`) are unchanged; `apply_patch_test` and `run-pov` are likewise unchanged.
 
 ### Added

--- a/docs/config/crs.md
+++ b/docs/config/crs.md
@@ -167,23 +167,35 @@ The CRS run phase is a dictionary where each key is a module name and each value
 
 ### CRSRunPhaseModule
 
+Every run module is built from a `dockerfile` by the framework ahead of the run and consumed read-only at run time. The `target_dependent` flag selects which earlier phase builds the image.
+
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `dockerfile` | `string` | Yes | - | Path to the Dockerfile (must contain "Dockerfile" or end with `.Dockerfile`). Can use `oss-crs-infra:` prefix for framework-provided services. |
+| `target_dependent` | `bool` | No | `false` | Whether the image depends on the specific target. `false` → built once during **prepare**; `true` → built during **build-target**, once per target. |
 | `additional_env` | `dict[string, string]` | No | `{}` | Additional environment variables to pass to the module. Keys must match `[A-Za-z_][A-Za-z0-9_]*`. |
+
+#### Build phase: `target_dependent`
+
+- **`target_dependent: false`** (default) — the image is *target-independent* (e.g. `FROM` a fixed base; the target is mounted at run time, not baked in). The framework builds it once during the **prepare** phase and tags it `oss-crs-runner:<crs>-<module>`. The `crs_version` build-arg and the `libcrs` build context are provided.
+- **`target_dependent: true`** — the image depends on the specific target (e.g. `FROM ${target_base_image}`). The framework builds it during the **build-target** phase, once per target, and tags it `oss-crs-runner:<crs>-<module>-<target_hash>`. In addition to `crs_version` and `libcrs`, the `target_base_image` and `base_runner_image` build-args are provided.
+
+The `oss-crs-runner:` prefix keeps these images out of the run-time teardown sweep. The images must be resolvable at run time — present locally (from prepare/build-target) or pullable from a registry when the run is online.
 
 ### Example
 
 ```yaml
 crs_run_phase:
-  module-1:
-    dockerfile: oss-crs/docker-compose/bug-finding.Dockerfile
+  # Target-independent: built once by prepare.
+  fuzzer:
+    dockerfile: oss-crs/dockerfiles/runner.Dockerfile
     additional_env:
       RUNNING_TIME_ENV: "XXX"
-  module-2:
-    dockerfile: oss-crs/docker-compose/bug-finding.Dockerfile
-    additional_env:
-      RUNNING_TIME_ENV: "XXX2"
+  # Target-dependent: built once per target by build-target
+  # (e.g. its Dockerfile is `FROM ${target_base_image}`).
+  lsp:
+    dockerfile: oss-crs/dockerfiles/lsp.Dockerfile
+    target_dependent: true
 ```
 
 **Note:** Builder and runner sidecars are injected automatically by the framework during the run phase. CRS developers do not need to declare them in `crs_run_phase`. The `BUILDER_MODULE` environment variable is set automatically.

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -79,8 +79,8 @@ CRS Compose is the top-level orchestrator that manages the entire lifecycle of a
 
 | Phase | Command | Description |
 |---|---|---|
-| **Prepare** | `oss-crs prepare` | Pulls CRS source repositories, builds Docker images using `docker buildx bake` |
-| **Build Target** | `oss-crs build-target` | Builds the target project (OSS-Fuzz format) and runs each CRS's target build pipeline |
+| **Prepare** | `oss-crs prepare` | Pulls CRS source repositories and builds target-independent Docker images |
+| **Build Target** | `oss-crs build-target` | Builds the target project (OSS-Fuzz format), runs each CRS's target build pipeline, and builds any target-dependent run images once per target |
 | **Run** | `oss-crs run` | Launches all CRSs and infrastructure via Docker Compose |
 
 **Configuration (`crs-compose.yaml`)** file declares:
@@ -102,7 +102,7 @@ Every CRS repository contains an `oss-crs/crs.yaml` file that declares:
 
 - **Prepare phase** — An HCL file for `docker buildx bake` to build the CRS images
 - **Target build phase** — A list of build steps, each with a Dockerfile and expected outputs
-- **Run phase** — A set of named modules (containers) that constitute the CRS at runtime
+- **Run phase** — A set of named modules (containers) that constitute the CRS at runtime. Each module is built from a `dockerfile:` ahead of the run (by prepare for target-independent modules, or build-target for `target_dependent: true` modules) and consumed read-only at run time (see [docs/config/crs.md](../config/crs.md#crsrunphasemodule))
 - **Supported targets** — Languages, sanitizers, and architectures the CRS supports
 - **Required LLMs** — Model names the CRS needs (validated against the LiteLLM config before launch)
 - **Required Inputs** — Input channels the CRS depends on (validated before container launch; e.g., `diff`, `bug-candidate`)

--- a/oss_crs/src/cli/clean.py
+++ b/oss_crs/src/cli/clean.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import docker
 import docker.errors
 
-from ..constants import PRESERVED_BUILDER_REPO
+from ..constants import PRESERVED_BUILDER_REPO, PRESERVED_RUNNER_REPO
 from ..utils import (
     confirm,
     get_console,
@@ -147,6 +147,23 @@ def discover_build_target_images(
         except docker.errors.ImageNotFound:
             pass
 
+    # Preserved runner images: oss-crs-runner:{crs_name}-{module}-{repo_hash}
+    # Produced by build-target for target-dependent run modules. Scope by CRS
+    # name (and by target repo hash when a target is provided).
+    repo_hash = target.get_docker_image_name().rsplit(":", 1)[-1] if target else None
+    for img in client.images.list(name=PRESERVED_RUNNER_REPO):
+        for tag in img.tags:
+            if not tag.startswith(f"{PRESERVED_RUNNER_REPO}:"):
+                continue
+            _, _, tag_suffix = tag.partition(":")
+            if not tag_suffix:
+                continue
+            for crs_name in crs_names:
+                if tag_suffix.startswith(f"{crs_name}-"):
+                    if repo_hash is None or tag_suffix.endswith(f"-{repo_hash}"):
+                        builder_tags.append(tag)
+                    break
+
     return (
         _dedupe(builder_tags),
         _dedupe(snapshot_tags),
@@ -169,10 +186,7 @@ def discover_run_images(crs_compose) -> list[str]:
     for img in client.images.list():
         for tag in img.tags:
             for rid in run_ids:
-                if (
-                    tag.startswith(f"crs_compose_{rid}")
-                    or tag == f"{rid}-oss-crs-litellm-key-gen:latest"
-                ):
+                if tag.startswith(f"crs_compose_{rid}"):
                     tags.append(tag)
                     break
     return _dedupe(tags)

--- a/oss_crs/src/cli/crs_compose.py
+++ b/oss_crs/src/cli/crs_compose.py
@@ -38,7 +38,12 @@ def add_common_arguments(parser):
         default=DEFAULT_WORK_DIR,
         help="Working directory for CRS Compose operations",
     )
-
+    parser.add_argument(
+        "--offline",
+        required=False,
+        help="Disables network access for CRS Compose operations",
+        action="store_true",
+    )
 
 def add_target_arguments(parser):
     parser.add_argument(
@@ -799,7 +804,7 @@ def cli() -> bool | int:
     # Skip CRS repo init for commands that don't need it
     skip_crs_init = args.command in ("artifacts", "archive")
     crs_compose = CRSCompose.from_yaml_file(
-        args.compose_file, args.work_dir, skip_crs_init=skip_crs_init
+        args.compose_file, args.work_dir, skip_crs_init=skip_crs_init, offline=args.offline
     )
 
     if args.command == "prepare":

--- a/oss_crs/src/cli/crs_compose.py
+++ b/oss_crs/src/cli/crs_compose.py
@@ -45,6 +45,7 @@ def add_common_arguments(parser):
         action="store_true",
     )
 
+
 def add_target_arguments(parser):
     parser.add_argument(
         "--fuzz-proj-path",
@@ -804,7 +805,10 @@ def cli() -> bool | int:
     # Skip CRS repo init for commands that don't need it
     skip_crs_init = args.command in ("artifacts", "archive")
     crs_compose = CRSCompose.from_yaml_file(
-        args.compose_file, args.work_dir, skip_crs_init=skip_crs_init, offline=args.offline
+        args.compose_file,
+        args.work_dir,
+        skip_crs_init=skip_crs_init,
+        offline=args.offline,
     )
 
     if args.command == "prepare":

--- a/oss_crs/src/config/crs.py
+++ b/oss_crs/src/config/crs.py
@@ -101,25 +101,31 @@ class TargetBuildPhase(BaseModel):
 class CRSRunPhaseModule(BaseModel):
     """Configuration for a single CRS run phase module.
 
-    The dockerfile can be:
-    - "oss-crs-infra:<module>": framework-provided service (e.g., default-builder)
-    - A file path: CRS developer's custom service Dockerfile
+    A module's run image is always *prebuilt* by the framework and consumed
+    read-only at run time. The build phase is selected by ``target_dependent``:
+
+    - ``target_dependent: false`` (default): the image is target-independent
+      and is built once during the prepare phase. Its tag is derived by the
+      framework as ``oss-crs-runner:<crs>-<module>``.
+    - ``target_dependent: true``: the image depends on the specific target
+      (e.g. ``FROM ${target_base_image}``) and is built during the
+      build-target phase, keyed by the target hash. Its tag is derived as
+      ``oss-crs-runner:<crs>-<module>-<target_hash>``.
+
+    ``dockerfile`` is always required and may be a file path or an
+    ``oss-crs-infra:<module>`` reference.
     """
 
-    dockerfile: Optional[str] = None
+    dockerfile: str
+    target_dependent: bool = False
     additional_env: dict[str, str] = Field(default_factory=dict)
-
-    @model_validator(mode="after")
-    def validate_dockerfile_requirement(self):
-        """Ensure dockerfile is always provided."""
-        if self.dockerfile is None:
-            raise ValueError("dockerfile is required")
-        return self
 
     @field_validator("dockerfile")
     @classmethod
-    def validate_dockerfile(cls, v: Optional[str]) -> Optional[str]:
-        return _validate_dockerfile_value(v)
+    def validate_dockerfile(cls, v: str) -> str:
+        result = _validate_dockerfile_value(v)
+        assert result is not None
+        return result
 
     @field_validator("additional_env")
     @classmethod

--- a/oss_crs/src/constants.py
+++ b/oss_crs/src/constants.py
@@ -3,6 +3,36 @@
 LITELLM_IMAGE = "ghcr.io/berriai/litellm-database@sha256:64d3547e0b131bf4638342e52c12bc46d6f1d9b8498e4b731ff31be5ab316ea9"  # v1.92.0
 POSTGRES_IMAGE = "postgres@sha256:b913fd5699b8bd23fa4b06d72ecdd939fad43b80fb8651bac06caa0e6d135cac"  # 18.4
 
+# Alpine image used by the cleanup helpers (``rm_with_docker`` and the
+# ``oss-crs clean`` size fallback), which shell out to ``docker run --rm alpine``
+# to delete/measure root-owned files during run teardown and clean. ``prepare``
+# pulls this pinned digest once (unconditionally, since cleanup runs regardless
+# of LLM mode) and tags it back to the bare ``alpine`` handle the helpers use, so
+# offline teardown/clean resolve it locally instead of pulling per invocation.
+ALPINE_IMAGE = "alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b"  # 3.x latest
+
+# Pinned-digest images pulled (not built) for the internal LiteLLM stack, each
+# mapped to a stable, infra-owned local tag. ``prepare`` pulls each by its
+# immutable digest once (gated on internal-LLM mode) and then applies the local
+# tag, so offline runs have them locally instead of pulling per run. Tagging is
+# additive: the pulled image keeps its RepoDigest, so the digest references in
+# the run template still resolve to the same local image, while the tag makes it
+# visible in ``docker images`` and gives it a usable, stable handle.
+OSS_CRS_INTERNAL_LLM_IMAGES = {
+    LITELLM_IMAGE: "oss-crs-litellm:latest",
+    POSTGRES_IMAGE: "oss-crs-postgres:latest",
+}
+
+# Internal-LLM-only sidecars that are *built* from oss-crs-infra contexts (as
+# opposed to the pinned images above, which are pulled). litellm-key-gen only
+# runs when the LLM stack is in ``internal`` mode, so ``prepare`` builds it with
+# its stable tag gated on that mode -- but the tag is always passed to the
+# renderer so the compose template can reference it. Maps each context
+# subdirectory under oss-crs-infra/ to its stable image tag.
+OSS_CRS_INTERNAL_LLM_SIDECAR_IMAGES = {
+    "litellm-key-gen": "oss-crs-litellm-key-gen:latest",
+}
+
 # Internal LiteLLM proxy URL exposed inside the Docker network.
 LITELLM_INTERNAL_URL = "http://litellm.oss-crs:4000"
 
@@ -19,6 +49,26 @@ PRESERVED_BUILDER_REPO = "oss-crs-builder"
 # specified (e.g. harness-gen CRSs that produce harnesses rather than consume them).
 # OSS_CRS_TARGET_HARNESS is NOT set in the container environment in this case.
 UNHARNESSED = "OSS_CRS_UNHARNESSED"
+
+# Docker repository name for target-dependent run-phase images. These are
+# produced by the build-target phase (tag embeds the target repo hash) and
+# consumed unbuilt by the run phase, so they must survive run-time teardown
+# sweeps just like preserved builder images.
+PRESERVED_RUNNER_REPO = "oss-crs-runner"
+
+# Infra sidecar images.
+# These sidecars (exchange, lifecycle, builder/runner sidecars) are built from
+# fixed oss-crs-infra contexts and take no target/CRS build args, so a single
+# image serves every CRS module and every target. ``prepare`` builds them once
+# with these stable, run-independent tags; the run phase reuses them instead of
+# rebuilding per run (and offline runs rely on them already existing locally).
+# Maps each context subdirectory under oss-crs-infra/ to its stable image tag.
+OSS_CRS_INFRA_SIDECAR_IMAGES = {
+    "exchange": "oss-crs-exchange:latest",
+    "lifecycle": "oss-crs-lifecycle:latest",
+    "builder-sidecar": "oss-crs-builder-sidecar:latest",
+    "runner-sidecar": "oss-crs-runner-sidecar:latest",
+}
 
 # OSS-Fuzz base-runner image. CRS run-phase runners (that execute harness
 # binaries) should start FROM this, tagged to match the OS the harness was

--- a/oss_crs/src/crs.py
+++ b/oss_crs/src/crs.py
@@ -12,7 +12,13 @@ from .env_policy import build_prepare_env
 from .ui import MultiTaskProgress, TaskResult
 from .target import Target, file_lock
 from .templates import renderer
-from .utils import TmpDockerCompose, log_dim, log_warning, preserved_builder_image_name
+from .utils import (
+    TmpDockerCompose,
+    log_dim,
+    log_warning,
+    preserved_builder_image_name,
+    preserved_runner_image_name,
+)
 from .workdir import WorkDir
 
 CRS_YAML_PATH = "oss-crs/crs.yaml"
@@ -67,10 +73,10 @@ def init_crs_repo(
         )
 
         if offline and not dest_path.exists():
-            error_msg = (
-                    f"Repository at {dest_path} does not exist and --offline is enabled."
+            return TaskResult(
+                success=False,
+                error=f"Repository at {dest_path} does not exist and --offline is enabled.",
             )
-            return TaskResult(success=False, error=error_msg)
         elif offline and dest_path.exists():
             tasks.append(reset_task)
         elif not offline and dest_path.exists():
@@ -281,6 +287,26 @@ class CRS:
         Returns:
             True if bake succeeded, False otherwise.
         """
+        bake_result = self.__prepare_bake(
+            multi_task_progress,
+            publish=publish,
+            docker_registry=docker_registry,
+            no_pull=no_pull,
+        )
+        if not bake_result.success:
+            return bake_result
+        # After baking (or pulling) the CRS images, build the target-independent
+        # run-phase images so the run phase can consume them read-only. Target-
+        # dependent run images are built later by build_target.
+        return self.__prepare_run_images(multi_task_progress)
+
+    def __prepare_bake(
+        self,
+        multi_task_progress: MultiTaskProgress,
+        publish: bool = False,
+        docker_registry: Optional[str] = None,
+        no_pull: bool = False,
+    ) -> "TaskResult":
         if self.config.prepare_phase is None:
             return TaskResult(success=True)
 
@@ -341,6 +367,108 @@ class CRS:
             cmd=cmd, cwd=self.crs_path, env=env, info_text=info_text
         )
 
+    def __target_independent_run_modules(self):
+        """Run-phase modules built by the prepare phase (``target_dependent: false``)."""
+        return [
+            (name, cfg)
+            for name, cfg in self.config.crs_run_phase.modules.items()
+            if not cfg.target_dependent
+        ]
+
+    def __target_dependent_run_modules(self):
+        """Run-phase modules built by the build-target phase (``target_dependent: true``).
+
+        These images depend on the specific target (e.g. ``FROM
+        ${target_base_image}``) and are keyed by the target hash.
+        """
+        return [
+            (name, cfg)
+            for name, cfg in self.config.crs_run_phase.modules.items()
+            if cfg.target_dependent
+        ]
+
+    def __prepare_run_images(
+        self, multi_task_progress: MultiTaskProgress
+    ) -> "TaskResult":
+        """Build all target-independent run-phase images during prepare."""
+        modules = self.__target_independent_run_modules()
+        if not modules:
+            return TaskResult(success=True)
+        for module_name, module_config in modules:
+            image_tag = preserved_runner_image_name(self.name, module_name)
+            multi_task_progress.add_task(
+                f"run image: {module_name}",
+                lambda p, mn=module_name, mc=module_config, tag=image_tag: (
+                    self.__build_run_image(
+                        module_name=mn,
+                        module_config=mc,
+                        image_tag=tag,
+                        progress=p,
+                        scope=f"{self.name}:prepare:{mn}",
+                    )
+                ),
+            )
+        return multi_task_progress.run_added_tasks()
+
+    def __build_run_image(
+        self,
+        module_name: str,
+        module_config,
+        image_tag: str,
+        progress: MultiTaskProgress,
+        scope: str,
+        build_args: Optional[dict[str, str]] = None,
+    ) -> "TaskResult":
+        """Build (and tag) one run-phase image directly with ``docker buildx build``.
+
+        The framework owns the image tag (``preserved_runner_image_name``) and
+        builds the module's run Dockerfile directly, exposing the framework
+        libCRS as the ``libcrs`` build context (mirroring the run compose).
+        Skips the build when the image already exists locally.
+        """
+        inspect = subprocess.run(
+            ["docker", "image", "inspect", image_tag],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if inspect.returncode == 0:
+            progress.add_note(f"{image_tag} already exists; skipping build")
+            return TaskResult(success=True)
+
+        dockerfile = renderer._resolve_module_dockerfile(
+            self.crs_path, module_config.dockerfile
+        )
+        env = build_prepare_env(
+            base_env=os.environ.copy(),
+            crs_additional_env=(
+                self.resource.additional_env if self.resource else None
+            ),
+            version=self.config.version,
+            scope=scope,
+        ).effective_env
+
+        args = {"crs_version": self.config.version, **(build_args or {})}
+        cmd = [
+            "docker",
+            "buildx",
+            "build",
+            "-f",
+            dockerfile,
+            "-t",
+            image_tag,
+            "--build-context",
+            f"libcrs={renderer.LIBCRS_PATH}",
+            "--load",
+        ]
+        for key, value in args.items():
+            cmd += ["--build-arg", f"{key}={value}"]
+        cmd.append(str(self.crs_path))
+
+        info_text = f"Module: {module_name}\nImage: {image_tag}"
+        return progress.run_command_with_streaming_output(
+            cmd=cmd, cwd=self.crs_path, env=env, info_text=info_text
+        )
+
     def __is_supported_target(self, target: Target) -> bool:
         _ = target
         return True
@@ -358,41 +486,64 @@ class CRS:
         input_hash: Optional[str] = None,
         target_source_path: Optional[Path] = None,
     ) -> "TaskResult":
-        if (
-            self.config.target_build_phase is None
-            or not self.config.target_build_phase.builds
-        ):
-            return TaskResult(success=True)
         if not self.__is_supported_target(target):
             return TaskResult(
                 success=True,
                 output=f"Skipping target {target.name} for CRS {self.name} as it is not supported.",
             )
-        builds = self.config.target_build_phase.builds
-        if not builds:
-            return TaskResult(success=True)
-        build_work_dir = self.work_dir.get_crs_build_dir(
-            self.name, target, build_id, sanitizer
+        builds = (
+            self.config.target_build_phase.builds
+            if self.config.target_build_phase is not None
+            else []
         )
-        for build_config in builds:
-            build_name = build_config.name
+        run_image_modules = self.__target_dependent_run_modules()
+        if not builds and not run_image_modules:
+            return TaskResult(success=True)
+        if builds:
+            build_work_dir = self.work_dir.get_crs_build_dir(
+                self.name, target, build_id, sanitizer
+            )
+            for build_config in builds:
+                build_name = build_config.name
+                progress.add_task(
+                    build_name,
+                    lambda p, build_name=build_name, build_config=build_config: (
+                        self.__build_target_one(
+                            target,
+                            target_base_image,
+                            build_name,
+                            build_config,
+                            build_work_dir,
+                            build_id,
+                            sanitizer,
+                            p,
+                            build_fetch_dir=build_fetch_dir,
+                            diff_path=diff_path,
+                            bug_candidate_dir=bug_candidate_dir,
+                            input_hash=input_hash,
+                            target_source_path=target_source_path,
+                        )
+                    ),
+                )
+        for module_name, module_config in run_image_modules:
+            target_repo_hash = target.get_docker_image_name().rsplit(":", 1)[-1]
+            image_tag = preserved_runner_image_name(
+                self.name, module_name, target_repo_hash
+            )
+            build_args = {
+                "target_base_image": target_base_image,
+                "base_runner_image": target.base_runner_image,
+            }
             progress.add_task(
-                build_name,
-                lambda p, build_name=build_name, build_config=build_config: (
-                    self.__build_target_one(
-                        target,
-                        target_base_image,
-                        build_name,
-                        build_config,
-                        build_work_dir,
-                        build_id,
-                        sanitizer,
-                        p,
-                        build_fetch_dir=build_fetch_dir,
-                        diff_path=diff_path,
-                        bug_candidate_dir=bug_candidate_dir,
-                        input_hash=input_hash,
-                        target_source_path=target_source_path,
+                f"run image: {module_name}",
+                lambda p, mn=module_name, mc=module_config, tag=image_tag, args=build_args: (
+                    self.__build_run_image(
+                        module_name=mn,
+                        module_config=mc,
+                        image_tag=tag,
+                        progress=p,
+                        scope=f"{self.name}:build-target:{mn}",
+                        build_args=args,
                     )
                 ),
             )

--- a/oss_crs/src/crs.py
+++ b/oss_crs/src/crs.py
@@ -24,6 +24,7 @@ def init_crs_repo(
     branch: str,
     dest_path: Path,
     skip_if_exists: bool = False,
+    offline: bool = False,
 ) -> TaskResult:
     # Use file lock to prevent race conditions when multiple runs access same CRS repo
     lock_path = dest_path.parent / f".{name}.lock"
@@ -33,40 +34,51 @@ def init_crs_repo(
             return TaskResult(success=True)
 
         tasks = []
-        if dest_path.exists():
-            tasks = [
-                (
-                    "Git Fetch",
-                    lambda progress: progress.run_command_with_streaming_output(
-                        cmd=["git", "fetch", "--recurse-submodules", "origin", branch],
-                        cwd=dest_path,
-                    ),
-                ),
-                (
-                    "Git Reset",
-                    lambda progress: progress.run_command_with_streaming_output(
-                        cmd=["git", "reset", "--hard", f"origin/{branch}"],
-                        cwd=dest_path,
-                    ),
-                ),
-            ]
+
+        fetch_task = (
+            "Git Fetch",
+            lambda progress: progress.run_command_with_streaming_output(
+                cmd=["git", "fetch", "--recurse-submodules", "origin", branch],
+                cwd=dest_path,
+            ),
+        )
+
+        reset_task = (
+            "Git Reset",
+            lambda progress: progress.run_command_with_streaming_output(
+                cmd=["git", "reset", "--hard", f"origin/{branch}"],
+                cwd=dest_path,
+            ),
+        )
+
+        clone_task = (
+            "Cloning CRS repository",
+            lambda progress: progress.run_command_with_streaming_output(
+                cmd=[
+                    "git",
+                    "clone",
+                    "--recurse-submodules",
+                    "--branch",
+                    branch,
+                    repo_url,
+                    str(dest_path),
+                ]
+            ),
+        )
+
+        if offline and not dest_path.exists():
+            error_msg = (
+                    f"Repository at {dest_path} does not exist and --offline is enabled."
+            )
+            return TaskResult(success=False, error=error_msg)
+        elif offline and dest_path.exists():
+            tasks.append(reset_task)
+        elif not offline and dest_path.exists():
+            tasks.append(fetch_task)
+            tasks.append(reset_task)
         else:
-            tasks = [
-                (
-                    "Cloning CRS repository",
-                    lambda progress: progress.run_command_with_streaming_output(
-                        cmd=[
-                            "git",
-                            "clone",
-                            "--recurse-submodules",
-                            "--branch",
-                            branch,
-                            repo_url,
-                            str(dest_path),
-                        ]
-                    ),
-                ),
-            ]
+            tasks.append(clone_task)
+
         with MultiTaskProgress(tasks, title=f"Init CRS: {name}") as progress:
             return progress.run_added_tasks()
 
@@ -85,6 +97,7 @@ class CRS:
         work_dir: "WorkDir",
         crs_compose_env: CRSComposeEnv,
         skip_init: bool = False,
+        offline: bool = False,
     ) -> "CRS":
         source = entry.source
         if source is None:
@@ -105,6 +118,7 @@ class CRS:
             branch,
             path,
             skip_if_exists=skip_init,
+            offline=offline,
         )
         if init_result.success:
             return cls(name, path, work_dir, entry, crs_compose_env)

--- a/oss_crs/src/crs_compose.py
+++ b/oss_crs/src/crs_compose.py
@@ -37,6 +37,13 @@ from .cgroup import (
     create_run_cgroups,
     cleanup_cgroup,
 )
+from .constants import (
+    ALPINE_IMAGE,
+    OSS_CRS_INFRA_SIDECAR_IMAGES,
+    OSS_CRS_INTERNAL_LLM_IMAGES,
+    OSS_CRS_INTERNAL_LLM_SIDECAR_IMAGES,
+)
+from .templates.renderer import OSS_CRS_ROOT_PATH
 from .libcrs_nix import build_deps_image
 
 import docker
@@ -44,22 +51,54 @@ import docker.errors
 import requests.exceptions
 
 
+def _lifecycle_needed(crs_list) -> bool:
+    """Whether the lifecycle sidecar will ever be started for this config.
+
+    Mirrors the run-compose template gate for ``oss-crs-lifecycle``: it is only
+    injected when there is a bug-fix ensemble *and* at least one non-ensemble
+    bug-fixing CRS with a run-phase module to watch (``exchange_dir`` in the
+    template is always truthy, so it drops out). All inputs come from static CRS
+    config, so this is fully determinable at prepare time -- letting prepare skip
+    building lifecycle for configs that can never use it.
+    """
+    has_bug_fix_ensemble = any(crs.config.is_bug_fixing_ensemble for crs in crs_list)
+    if not has_bug_fix_ensemble:
+        return False
+    return any(
+        crs.config.is_bug_fixing
+        and not crs.config.is_bug_fixing_ensemble
+        and any(
+            module.dockerfile for module in crs.config.crs_run_phase.modules.values()
+        )
+        for crs in crs_list
+    )
+
+
 class CRSCompose:
     @classmethod
     def from_yaml_file(
-        cls, compose_file: Path, work_dir: Path, skip_crs_init: bool = False, offline: bool = False
+        cls,
+        compose_file: Path,
+        work_dir: Path,
+        skip_crs_init: bool = False,
+        offline: bool = False,
     ) -> "CRSCompose":
         config = CRSComposeConfig.from_yaml_file(compose_file)
         return cls(config, work_dir, skip_crs_init=skip_crs_init, offline=offline)
 
     def __init__(
-        self, config: CRSComposeConfig, work_dir: Path, skip_crs_init: bool = False, offline: bool = False
+        self,
+        config: CRSComposeConfig,
+        work_dir: Path,
+        skip_crs_init: bool = False,
+        offline: bool = False,
     ):
         hash = config.md5_hash()
         self.config = config
         self.llm = LLM(self.config.llm_config)
         self.work_dir = WorkDir(work_dir / f"crs_compose/{hash}")
         self.crs_compose_env = CRSComposeEnv(self.config.run_env)
+        self.offline = offline
         self.crs_list = [
             CRS.from_crs_compose_entry(
                 name,
@@ -585,6 +624,161 @@ class CRSCompose:
     def __prepare_oss_crs_infra(
         self, publish: bool = False, docker_registry: Optional[str] = None
     ) -> "TaskResult":
+        result = self.__build_infra_sidecar_images(self.__needed_infra_sidecar_images())
+        if not result.success:
+            return result
+        # The alpine cleanup image is used by run teardown and `oss-crs clean`
+        # regardless of LLM mode, so pull it unconditionally here (before the
+        # internal-mode gate) so offline teardown/clean find it locally.
+        result = self.__pull_cleanup_image()
+        if not result.success:
+            return result
+
+        result = self.__build_oss_crs_deps()
+        if not result.success:
+            return result
+        # The internal LiteLLM stack (litellm-key-gen sidecar + the pinned
+        # LiteLLM/Postgres images) only runs in internal-LLM mode. Prepare it
+        # here, gated on that mode, so the run phase (and especially offline
+        # runs) finds these images locally instead of building/pulling per run.
+        if self.llm.exists() and self.llm.mode == "internal":
+            result = self.__build_infra_sidecar_images(
+                OSS_CRS_INTERNAL_LLM_SIDECAR_IMAGES
+            )
+            if not result.success:
+                return result
+            return self.__pull_internal_llm_images()
+        return result
+
+    def __needed_infra_sidecar_images(self) -> dict:
+        """The base infra sidecar images this config can actually use.
+
+        exchange and the builder/runner sidecars are unconditionally injected
+        into every run, so they are always built. lifecycle is conditional on
+        the (config-derivable) bug-fix-ensemble topology, so it is dropped when
+        ``_lifecycle_needed`` says no run will ever start it.
+        """
+
+        images = dict(OSS_CRS_INFRA_SIDECAR_IMAGES)
+        if "lifecycle" in images and not _lifecycle_needed(self.crs_list):
+            del images["lifecycle"]
+        return images
+
+    def __pull_cleanup_image(self) -> "TaskResult":
+        """Pull the pinned alpine cleanup image once, at prepare time.
+
+        ``rm_with_docker`` and the ``oss-crs clean`` size fallback shell out to
+        ``docker run --rm ... alpine ...`` to delete/measure root-owned files
+        during run teardown and clean. Those run regardless of LLM mode, so this
+        is pulled unconditionally. The pinned digest is tagged back to the bare
+        ``alpine`` handle the helpers reference (tagging is additive -- the image
+        keeps its RepoDigest), so offline teardown/clean resolve it locally
+        instead of pulling per invocation.
+        """
+
+        result = subprocess.run(
+            ["docker", "pull", ALPINE_IMAGE],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            return TaskResult(
+                success=False,
+                error=(
+                    f"Failed to pull cleanup image '{ALPINE_IMAGE}':\n{result.stderr}"
+                ),
+            )
+        tag_result = subprocess.run(
+            ["docker", "tag", ALPINE_IMAGE, "alpine"],
+            capture_output=True,
+            text=True,
+        )
+        if tag_result.returncode != 0:
+            return TaskResult(
+                success=False,
+                error=(
+                    f"Failed to tag cleanup image '{ALPINE_IMAGE}' as "
+                    f"'alpine':\n{tag_result.stderr}"
+                ),
+            )
+        return TaskResult(success=True)
+
+    def __pull_internal_llm_images(self) -> "TaskResult":
+        """Pull the pinned internal LiteLLM/Postgres images once, at prepare time.
+
+        These sidecars only run when the LLM stack is in ``internal`` mode, so
+        pulling is gated on that mode. The images are referenced by immutable
+        digests, so a single pull serves every CRS module and target. Each
+        pulled image is then tagged with a stable, infra-owned local tag: the
+        tag is additive (the image keeps its RepoDigest, so the digest
+        references in the run template still resolve), but it makes the image
+        visible in ``docker images`` and gives it a usable, stable handle.
+        """
+        for image, local_tag in OSS_CRS_INTERNAL_LLM_IMAGES.items():
+            result = subprocess.run(
+                ["docker", "pull", image],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                return TaskResult(
+                    success=False,
+                    error=(
+                        f"Failed to pull internal LLM image '{image}':\n{result.stderr}"
+                    ),
+                )
+            tag_result = subprocess.run(
+                ["docker", "tag", image, local_tag],
+                capture_output=True,
+                text=True,
+            )
+            if tag_result.returncode != 0:
+                return TaskResult(
+                    success=False,
+                    error=(
+                        f"Failed to tag internal LLM image '{image}' "
+                        f"as '{local_tag}':\n{tag_result.stderr}"
+                    ),
+                )
+        return TaskResult(success=True)
+
+    def __build_infra_sidecar_images(
+        self, images: Optional[dict] = None
+    ) -> "TaskResult":
+        """Build shared infra sidecar images once, with stable tags.
+
+        The exchange, lifecycle and builder/runner sidecars (the default
+        ``images`` registry) are built from fixed oss-crs-infra contexts and
+        take no target/CRS build args, so a single image serves every CRS module
+        and every target. Building them here (at prepare time) with
+        run-independent tags lets the run phase reuse them instead of rebuilding
+        per run; offline runs rely on them already existing locally. The same
+        machinery builds the internal-LLM-only sidecars when an explicit
+        ``images`` registry is passed.
+        """
+        if images is None:
+            images = OSS_CRS_INFRA_SIDECAR_IMAGES
+
+        infra_root = OSS_CRS_ROOT_PATH / "oss-crs-infra"
+        for subdir, tag in images.items():
+            context = infra_root / subdir
+            result = subprocess.run(
+                ["docker", "build", "-t", tag, str(context)],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                return TaskResult(
+                    success=False,
+                    error=(
+                        f"Failed to build infra sidecar image '{tag}' "
+                        f"from {context}:\n{result.stderr}"
+                    ),
+                )
+
+        return TaskResult(success=True)
+
+    def __build_oss_crs_deps(self) -> "TaskResult":
         """Build the oss-crs-deps Docker image (libCRS + rsync via Nix).
 
         This is a framework-level prepare step that runs once during prepare.
@@ -595,12 +789,12 @@ class CRSCompose:
         """
         libcrs_dir = renderer.LIBCRS_PATH
         success, detail = build_deps_image(libcrs_dir)
+
+        error = ""
         if not success:
-            return TaskResult(
-                success=False,
-                error=f"Failed to build oss-crs-deps image: {detail}",
-            )
-        return TaskResult(success=True)
+            error = f"Failed to build oss-crs-deps image: {detail}"
+
+        return TaskResult(success=success, error=error)
 
     def prepare(self, publish: bool = False, no_pull: bool = False) -> bool:
         # Collect task names (infra + all CRS)
@@ -1778,12 +1972,19 @@ class CRSCompose:
         progress.add_task(
             "Prepare combined docker compose file", prepare_docker_compose
         )
-        progress.add_task(
-            "Build docker images in the combined docker compose file",
-            lambda progress: progress.docker_compose_build(
-                project_name, docker_compose_path
-            ),
-        )
+
+        if not self.offline:
+            progress.add_task(
+                "Build docker images in the combined docker compose file",
+                lambda progress: progress.docker_compose_build(
+                    project_name, docker_compose_path
+                ),
+            )
+        else:
+            progress.add_note(
+                "Skipping docker image build (--offline); "
+                "relying on pre-existing local images."
+            )
 
         return progress.run_added_tasks()
 

--- a/oss_crs/src/crs_compose.py
+++ b/oss_crs/src/crs_compose.py
@@ -47,13 +47,13 @@ import requests.exceptions
 class CRSCompose:
     @classmethod
     def from_yaml_file(
-        cls, compose_file: Path, work_dir: Path, skip_crs_init: bool = False
+        cls, compose_file: Path, work_dir: Path, skip_crs_init: bool = False, offline: bool = False
     ) -> "CRSCompose":
         config = CRSComposeConfig.from_yaml_file(compose_file)
-        return cls(config, work_dir, skip_crs_init=skip_crs_init)
+        return cls(config, work_dir, skip_crs_init=skip_crs_init, offline=offline)
 
     def __init__(
-        self, config: CRSComposeConfig, work_dir: Path, skip_crs_init: bool = False
+        self, config: CRSComposeConfig, work_dir: Path, skip_crs_init: bool = False, offline: bool = False
     ):
         hash = config.md5_hash()
         self.config = config
@@ -67,6 +67,7 @@ class CRSCompose:
                 self.work_dir,
                 self.crs_compose_env,
                 skip_init=skip_crs_init,
+                offline=offline,
             )
             for name, crs_cfg in self.config.crs_entries.items()
         ]

--- a/oss_crs/src/target.py
+++ b/oss_crs/src/target.py
@@ -233,7 +233,7 @@ class Target:
         return hashlib.sha256(key_source.encode()).hexdigest()[:12]
 
     def get_docker_image_name(self) -> str:
-        repo_hash = self.__get_repo_hash()
+        repo_hash = self.get_repo_hash()
         return f"{self.name}:{repo_hash}"
 
     @property
@@ -255,7 +255,7 @@ class Target:
     def build_docker_image(self) -> str | None:
         if self._has_repo and not self.init_repo():
             return None
-        repo_hash = self.__get_repo_hash()
+        repo_hash = self.get_repo_hash()
         image_tag = self.get_docker_image_name()
 
         # Skip rebuild if the image already exists locally
@@ -288,7 +288,6 @@ class Target:
                 return self.__build_docker_image_plain(image_tag, progress)
 
             head_items = [
-                ui.bold(f"Proj hash: {repo_hash} (calculated from {self.proj_path})"),
                 ui.bold(f"Image tag: {image_tag}"),
             ]
 
@@ -378,7 +377,7 @@ class Target:
                 hasher.update(fp.read_bytes())
         return hasher.hexdigest()[:12]
 
-    def __get_repo_hash(self) -> str:
+    def get_repo_hash(self) -> str:
         """
         Get a hash representing the current state of the repository.
 

--- a/oss_crs/src/templates/renderer.py
+++ b/oss_crs/src/templates/renderer.py
@@ -9,6 +9,8 @@ from ..config.crs import CRSType, OSS_CRS_INFRA_PREFIX
 from ..constants import (
     LITELLM_IMAGE,
     LITELLM_INTERNAL_URL,
+    OSS_CRS_INFRA_SIDECAR_IMAGES,
+    OSS_CRS_INTERNAL_LLM_SIDECAR_IMAGES,
     POSTGRES_HOST,
     POSTGRES_IMAGE,
     POSTGRES_PORT,
@@ -16,7 +18,11 @@ from ..constants import (
 )
 from ..env_policy import build_run_service_env, build_target_builder_env
 from ..llm import DEFAULT_LITELLM_CONFIG_PATH
-from ..utils import generate_random_key, preserved_builder_image_name
+from ..utils import (
+    generate_random_key,
+    preserved_builder_image_name,
+    preserved_runner_image_name,
+)
 
 if TYPE_CHECKING:
     from ..crs import CRS
@@ -371,7 +377,18 @@ def render_run_crs_compose_docker_compose(
         "build_id": build_id,
         "sanitizer": sanitizer,
         "oss_crs_infra_root_path": str(OSS_CRS_ROOT_PATH / "oss-crs-infra"),
+        "infra_sidecar_images": {
+            **OSS_CRS_INFRA_SIDECAR_IMAGES,
+            **OSS_CRS_INTERNAL_LLM_SIDECAR_IMAGES,
+        },
         "resolve_dockerfile": _resolve_module_dockerfile,
+        "run_module_image": lambda crs_name, module_name, module_config: (
+            preserved_runner_image_name(
+                crs_name,
+                module_name,
+                target.get_repo_hash() if module_config.target_dependent else None,
+            )
+        ),
         "fetch_dir": fetch_dir,
         "exchange_dir": exchange_dir,
         "processed_exchange_dir": processed_exchange_dir,

--- a/oss_crs/src/templates/run-crs-compose.docker-compose.yaml.j2
+++ b/oss_crs/src/templates/run-crs-compose.docker-compose.yaml.j2
@@ -23,15 +23,7 @@ services:
 {% if module_config.dockerfile %}
   {{ crs.name }}_{{ module_name }}:
     privileged: true
-    build:
-      context: {{ crs.crs_path }}
-      dockerfile: {{ resolve_dockerfile(crs.crs_path, module_config.dockerfile) }}
-      additional_contexts:
-        libcrs: {{ libCRS_path }}
-      args:
-        - target_base_image={{target.get_docker_image_name()}}
-        - base_runner_image={{ target.base_runner_image }}
-        - crs_version={{ crs.config.version }}
+    image: {{ run_module_image(crs.name, module_name, module_config) }}
     environment:
 {%- for env_key, env_value in module_envs[crs.name + "_" + module_name].items() %}
       - {{ env_key }}={{ env_value }}
@@ -142,11 +134,8 @@ services:
         aliases:
           - {{ postgres_host }}
   oss-crs-litellm-key-gen:
-    image: {{ crs_compose_name }}-oss-crs-litellm-key-gen:latest
+    image: {{ infra_sidecar_images['litellm-key-gen'] }}
     attach: false
-    build:
-      context: {{ oss_crs_infra_root_path }}/litellm-key-gen
-      dockerfile: {{ oss_crs_infra_root_path }}/litellm-key-gen/Dockerfile
     depends_on:
       oss-crs-litellm:
         condition: service_healthy
@@ -174,8 +163,7 @@ services:
   ###########################################
 {%- if exchange_dir %}
   oss-crs-exchange:
-    build:
-      context: {{ oss_crs_infra_root_path }}/exchange
+    image: {{ infra_sidecar_images['exchange'] }}
     attach: false
     restart: on-failure:3
     volumes:
@@ -193,8 +181,7 @@ services:
   ###########################################
 {%- if processed_exchange_dir %}
   oss-crs-processed-exchange:
-    build:
-      context: {{ oss_crs_infra_root_path }}/exchange
+    image: {{ infra_sidecar_images['exchange'] }}
     attach: false
     restart: on-failure:3
     volumes:
@@ -223,8 +210,7 @@ services:
 {%- endfor %}
 {%- if bug_fix_ensemble and exchange_dir and watch_services %}
   oss-crs-lifecycle:
-    build:
-      context: {{ oss_crs_infra_root_path }}/lifecycle
+    image: {{ infra_sidecar_images['lifecycle'] }}
     attach: false
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -283,8 +269,7 @@ services:
   # OSS-CRS-BUILDER-SIDECAR
   ###########################################
   oss-crs-builder-sidecar:
-    build:
-      context: {{ oss_crs_infra_root_path }}/builder-sidecar
+    image: {{ infra_sidecar_images['builder-sidecar'] }}
     attach: false
     restart: on-failure:3
     volumes:
@@ -348,8 +333,7 @@ services:
   # OSS-CRS-RUNNER-SIDECAR
   ###########################################
   oss-crs-runner-sidecar:
-    build:
-      context: {{ oss_crs_infra_root_path }}/runner-sidecar
+    image: {{ infra_sidecar_images['runner-sidecar'] }}
     attach: false
     restart: on-failure:3
     volumes:

--- a/oss_crs/src/ui.py
+++ b/oss_crs/src/ui.py
@@ -12,7 +12,7 @@ from typing import Callable, Optional
 import yaml
 from rich.console import Console, Group
 
-from .constants import PRESERVED_BUILDER_REPO
+from .constants import PRESERVED_BUILDER_REPO, PRESERVED_RUNNER_REPO
 from .utils import bold, get_console, green, log_error, yellow  # noqa: F401 (re-exported)
 from rich.live import Live
 from rich.markup import escape
@@ -1314,8 +1314,13 @@ class MultiTaskProgress:
 
             # Don't remove preserved builder images — they're tagged copies of
             # compose-built images kept for the sidecar and snapshot workflows.
+            # Likewise keep preserved runner images — target-dependent run-phase
+            # images produced by build-target and consumed unbuilt by run.
             image_refs = {
-                r for r in image_refs if not r.startswith(f"{PRESERVED_BUILDER_REPO}:")
+                r
+                for r in image_refs
+                if not r.startswith(f"{PRESERVED_BUILDER_REPO}:")
+                and not r.startswith(f"{PRESERVED_RUNNER_REPO}:")
             }
             if image_refs:
                 rm_result = subprocess.run(

--- a/oss_crs/src/utils.py
+++ b/oss_crs/src/utils.py
@@ -13,7 +13,7 @@ from typing import Optional
 import questionary
 from rich.console import Console
 
-from .constants import PRESERVED_BUILDER_REPO
+from .constants import PRESERVED_BUILDER_REPO, PRESERVED_RUNNER_REPO
 
 
 RAND_CHARS = string.ascii_lowercase + string.digits
@@ -175,6 +175,29 @@ def preserved_builder_image_name(crs_name: str, build_name: str, build_id: str) 
     compose template for BASE_IMAGE_* env vars.
     """
     return f"{PRESERVED_BUILDER_REPO}:{crs_name}-{build_name}-{build_id}"
+
+
+def preserved_runner_image_name(
+    crs_name: str, module_name: str, target_hash: Optional[str] = None
+) -> str:
+    """Framework-derived tag for a prebuilt run-phase image.
+
+    Both the producer (prepare / build-target, which builds and tags the image)
+    and the consumer (the run renderer, which references it) call this so the
+    two agree by construction -- the tag is never written down in crs.yaml.
+
+    - Target-independent modules (built by prepare) omit ``target_hash`` and
+      get ``oss-crs-runner:<crs>-<module>``.
+    - Target-dependent modules (built by build-target) pass the target hash and
+      get ``oss-crs-runner:<crs>-<module>-<target_hash>``.
+
+    The ``oss-crs-runner:`` prefix is what keeps the image out of the run-time
+    teardown sweep (see ui.py / cli/clean.py).
+    """
+    base = f"{PRESERVED_RUNNER_REPO}:{crs_name}-{module_name}"
+    if target_hash:
+        return f"{base}-{target_hash}"
+    return base
 
 
 def build_snapshot_tag(crs_name: str, build_name: str, build_id: str) -> str:

--- a/oss_crs/tests/integration/test_builder_sidecar_full.py
+++ b/oss_crs/tests/integration/test_builder_sidecar_full.py
@@ -59,7 +59,7 @@ def test_builder_sidecar_full(cli_runner, sidecar_full_compose, mock_repo):
         "prepare",
         "--compose-file",
         compose,
-        timeout=120,
+        timeout=600,
     )
     assert result.returncode == 0, f"prepare failed:\n{result.stdout[-2000:]}"
 

--- a/oss_crs/tests/integration/test_resource_limits.py
+++ b/oss_crs/tests/integration/test_resource_limits.py
@@ -103,6 +103,19 @@ def test_run_enforces_memory_limits_in_active_mode(
     run_id = "resource-run"
     expected_memory = parse_memory("192M")
 
+    # The run modules (fuzzer/analyzer/monitor) are target-independent, so their
+    # images are built during prepare. Run it first or the run phase has no
+    # images to start and produces no memory logs.
+    prepare_result = cli_runner(
+        "prepare",
+        "--compose-file",
+        str(dummy_compose_file),
+        "--work-dir",
+        str(work_dir),
+        timeout=300,
+    )
+    assert prepare_result.returncode == 0, f"prepare failed: {prepare_result.stderr}"
+
     build_result = cli_runner(
         "build-target",
         "--compose-file",
@@ -187,6 +200,18 @@ def test_containers_within_crs_share_memory_limit(
     """
     build_id = "shared-mem-build"
     run_id = "shared-mem-run"
+
+    # Target-independent run modules are built during prepare; run it first so
+    # the run phase has images to start.
+    prepare_result = cli_runner(
+        "prepare",
+        "--compose-file",
+        str(dummy_compose_file),
+        "--work-dir",
+        str(work_dir),
+        timeout=300,
+    )
+    assert prepare_result.returncode == 0, f"prepare failed: {prepare_result.stderr}"
 
     build_result = cli_runner(
         "build-target",
@@ -418,6 +443,18 @@ def test_multi_crs_different_resource_limits(
     """
     build_id = "multi-crs-build"
     run_id = "multi-crs-run"
+
+    # Target-independent run modules are built during prepare; run it first so
+    # the run phase has images to start.
+    prepare_result = cli_runner(
+        "prepare",
+        "--compose-file",
+        str(multi_crs_compose_file),
+        "--work-dir",
+        str(work_dir),
+        timeout=300,
+    )
+    assert prepare_result.returncode == 0, f"prepare failed: {prepare_result.stderr}"
 
     build_result = cli_runner(
         "build-target",

--- a/oss_crs/tests/unit/config/test_crs.py
+++ b/oss_crs/tests/unit/config/test_crs.py
@@ -63,10 +63,26 @@ class TestBuildConfig:
 class TestCRSRunPhaseModule:
     """Tests for CRSRunPhaseModule - run phase service configuration."""
 
-    def test_module_requires_dockerfile_always(self):
-        """All modules must specify a Dockerfile."""
-        with pytest.raises(ValidationError, match="dockerfile is required"):
+    def test_module_requires_dockerfile(self):
+        """A module must specify a dockerfile."""
+        with pytest.raises(ValidationError):
             CRSRunPhaseModule()
+
+    def test_module_defaults_to_target_independent(self):
+        """Without target_dependent the image is built at prepare."""
+        module = CRSRunPhaseModule(dockerfile="run.Dockerfile")
+        assert module.dockerfile == "run.Dockerfile"
+        assert module.target_dependent is False
+
+    def test_module_target_dependent_flag(self):
+        """target_dependent opts the module into the build-target phase."""
+        module = CRSRunPhaseModule(dockerfile="run.Dockerfile", target_dependent=True)
+        assert module.target_dependent is True
+
+    def test_module_accepts_infra_reference(self):
+        """An oss-crs-infra:<module> reference is a valid dockerfile."""
+        module = CRSRunPhaseModule(dockerfile="oss-crs-infra:runner-sidecar")
+        assert module.dockerfile == "oss-crs-infra:runner-sidecar"
 
     def test_rejects_invalid_additional_env_key(self):
         with pytest.raises(ValidationError, match="invalid env var key"):

--- a/oss_crs/tests/unit/test_cli_clean.py
+++ b/oss_crs/tests/unit/test_cli_clean.py
@@ -386,23 +386,6 @@ class TestRunImageDiscovery:
             "crs_compose_1700000000ab-litellm:latest",
         }
 
-    def test_matches_litellm_key_gen_image(self):
-        compose = _make_crs_compose(
-            crs_names=["atlantis-c"],
-            build_ids=[],
-            run_ids=["run123"],
-        )
-        images = [
-            _make_image(["run123-oss-crs-litellm-key-gen:latest"]),
-        ]
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
-            client = mock_docker.from_env.return_value
-            client.images.list.return_value = images
-
-            result = discover_run_images(compose)
-
-        assert result == ["run123-oss-crs-litellm-key-gen:latest"]
-
     def test_ignores_images_from_different_run_id(self):
         compose = _make_crs_compose(
             crs_names=["atlantis-c"],

--- a/oss_crs/tests/unit/test_crs_prepare.py
+++ b/oss_crs/tests/unit/test_crs_prepare.py
@@ -13,6 +13,7 @@ class _CaptureProgress:
     def __init__(self):
         self.calls = []
         self.notes = []
+        self._tasks = []
 
     def run_command_with_streaming_output(
         self, cmd, cwd=None, env=None, info_text=None
@@ -29,6 +30,18 @@ class _CaptureProgress:
 
     def add_note(self, text):
         self.notes.append(text)
+
+    def add_task(self, name, func):
+        self._tasks.append((name, func))
+
+    def run_added_tasks(self):
+        result = TaskResult(success=True)
+        for _name, func in self._tasks:
+            r = func(self)
+            if not r.success:
+                result = r
+        self._tasks = []
+        return result
 
 
 def _write_minimal_crs_yaml(crs_root, version: str = "1.2.3"):
@@ -118,7 +131,7 @@ def test_prepare_forwards_resource_additional_env(tmp_path):
     # Mock subprocess so _try_pull_prebuilt_images fails (bake --print fails),
     # falling through to the bake command captured by _CaptureProgress.
     with patch("oss_crs.src.crs.subprocess.run", return_value=MagicMock(returncode=1)):
-        result = crs.prepare(multi_task_progress=progress)
+        result = crs._CRS__prepare_bake(multi_task_progress=progress)
 
     assert result.success is True
     assert len(progress.calls) == 1
@@ -132,7 +145,7 @@ def test_prepare_keeps_crs_version_over_additional_env(tmp_path):
     progress = _CaptureProgress()
 
     with patch("oss_crs.src.crs.subprocess.run", return_value=MagicMock(returncode=1)):
-        result = crs.prepare(multi_task_progress=progress)
+        result = crs._CRS__prepare_bake(multi_task_progress=progress)
 
     assert result.success is True
     assert len(progress.calls) == 1
@@ -151,7 +164,7 @@ def test_prepare_does_not_override_hcl_cache_from(tmp_path):
     progress = _CaptureProgress()
 
     with patch("oss_crs.src.crs.subprocess.run", return_value=MagicMock(returncode=1)):
-        result = crs.prepare(
+        result = crs._CRS__prepare_bake(
             multi_task_progress=progress, docker_registry="ghcr.io/example"
         )
 
@@ -180,7 +193,7 @@ def test_prepare_pulls_prebuilt_images_when_available(tmp_path):
     mock_run, calls_log = _mock_subprocess_for_pull(bake_plan, pull_succeeds=True)
 
     with patch("oss_crs.src.crs.subprocess.run", side_effect=mock_run):
-        result = crs.prepare(multi_task_progress=progress)
+        result = crs._CRS__prepare_bake(multi_task_progress=progress)
 
     assert result.success is True
     # Should NOT have fallen through to bake
@@ -223,7 +236,7 @@ def test_prepare_falls_back_to_bake_when_pull_fails(tmp_path):
     mock_run, _ = _mock_subprocess_for_pull(bake_plan, pull_succeeds=False)
 
     with patch("oss_crs.src.crs.subprocess.run", side_effect=mock_run):
-        result = crs.prepare(multi_task_progress=progress)
+        result = crs._CRS__prepare_bake(multi_task_progress=progress)
 
     assert result.success is True
     # Should have fallen through to bake
@@ -237,7 +250,7 @@ def test_prepare_skips_pull_when_publishing(tmp_path):
     progress = _CaptureProgress()
 
     with patch("oss_crs.src.crs.subprocess.run") as mock_run:
-        result = crs.prepare(
+        result = crs._CRS__prepare_bake(
             multi_task_progress=progress,
             publish=True,
             docker_registry="ghcr.io/example",
@@ -271,7 +284,7 @@ def test_prepare_falls_back_when_no_registry_tags(tmp_path):
         return result
 
     with patch("oss_crs.src.crs.subprocess.run", side_effect=mock_run):
-        result = crs.prepare(multi_task_progress=progress)
+        result = crs._CRS__prepare_bake(multi_task_progress=progress)
 
     assert result.success is True
     # Should have fallen through to bake
@@ -284,7 +297,7 @@ def test_prepare_falls_back_when_bake_print_fails(tmp_path):
     progress = _CaptureProgress()
 
     with patch("oss_crs.src.crs.subprocess.run", return_value=MagicMock(returncode=1)):
-        result = crs.prepare(multi_task_progress=progress)
+        result = crs._CRS__prepare_bake(multi_task_progress=progress)
 
     assert result.success is True
     # Should have fallen through to bake
@@ -297,7 +310,7 @@ def test_prepare_no_pull_skips_pull_and_builds(tmp_path):
     progress = _CaptureProgress()
 
     with patch("oss_crs.src.crs.subprocess.run") as mock_run:
-        result = crs.prepare(multi_task_progress=progress, no_pull=True)
+        result = crs._CRS__prepare_bake(multi_task_progress=progress, no_pull=True)
 
     assert result.success is True
     # Should NOT have called subprocess.run (no pull attempt)
@@ -305,3 +318,156 @@ def test_prepare_no_pull_skips_pull_and_builds(tmp_path):
     # Should have gone straight to bake
     assert len(progress.calls) == 1
     assert "bake" in progress.calls[0]["cmd"]
+
+
+# ---------------------------------------------------------------------------
+# Run image builds (prepare = target-independent, build-target = target-dependent)
+# ---------------------------------------------------------------------------
+
+
+def _write_run_module_crs_yaml(crs_root, *, target_dependent: bool):
+    """A crs.yaml whose single run module is built directly from a Dockerfile."""
+    flag = "\n            target_dependent: true" if target_dependent else ""
+    crs_yaml = textwrap.dedent(
+        f"""\
+        name: test-crs
+        type: [bug-fixing]
+        version: 1.2.3
+        crs_run_phase:
+          lsp:
+            dockerfile: oss-crs/lsp.Dockerfile{flag}
+        supported_target:
+          mode: [full]
+          language: [c]
+          sanitizer: [address]
+          architecture: [x86_64]
+        """
+    )
+    (crs_root / "oss-crs").mkdir(parents=True)
+    (crs_root / "oss-crs" / "crs.yaml").write_text(crs_yaml)
+
+
+def _make_run_module_crs(tmp_path, *, target_dependent: bool) -> CRS:
+    crs_root = tmp_path / "crs"
+    _write_run_module_crs_yaml(crs_root, target_dependent=target_dependent)
+    resource = CRSEntry(
+        cpuset="0-1",
+        memory="2G",
+        source=CRSSource(local_path=str(crs_root)),
+        additional_env={},
+    )
+    return CRS(
+        name="test-crs",
+        crs_path=crs_root,
+        work_dir=WorkDir(tmp_path / "work"),
+        resource=resource,
+        crs_compose_env=None,
+    )
+
+
+class _FakeTarget:
+    def __init__(self, image_name="proj:deadbeef99"):
+        self._image_name = image_name
+        self.base_runner_image = "gcr.io/oss-fuzz-base/base-runner:ubuntu-24-04"
+
+    def get_docker_image_name(self):
+        return self._image_name
+
+
+def test_build_run_image_skips_when_image_exists(tmp_path):
+    """Skip the build when the derived image already exists locally."""
+    crs = _make_run_module_crs(tmp_path, target_dependent=False)
+    progress = _CaptureProgress()
+    module_config = crs.config.crs_run_phase.modules["lsp"]
+
+    # docker image inspect returns 0 -> image present
+    with patch(
+        "oss_crs.src.crs.subprocess.run", return_value=MagicMock(returncode=0)
+    ) as mock_run:
+        result = crs._CRS__build_run_image(
+            module_name="lsp",
+            module_config=module_config,
+            image_tag="oss-crs-runner:test-crs-lsp",
+            progress=progress,
+            scope="test-crs:prepare:lsp",
+        )
+
+    assert result.success is True
+    # Only the inspect ran; no build invoked.
+    assert mock_run.call_count == 1
+    assert len(progress.calls) == 0
+    assert any("already exists" in n for n in progress.notes)
+
+
+def test_build_run_image_builds_with_tag_context_and_args(tmp_path):
+    """When the image is absent, build the Dockerfile directly with tag/context/args."""
+    crs = _make_run_module_crs(tmp_path, target_dependent=True)
+    progress = _CaptureProgress()
+    module_config = crs.config.crs_run_phase.modules["lsp"]
+
+    with patch("oss_crs.src.crs.subprocess.run", return_value=MagicMock(returncode=1)):
+        result = crs._CRS__build_run_image(
+            module_name="lsp",
+            module_config=module_config,
+            image_tag="oss-crs-runner:test-crs-lsp-deadbeef99",
+            progress=progress,
+            scope="test-crs:build-target:lsp",
+            build_args={
+                "target_base_image": "proj:deadbeef99",
+                "base_runner_image": "base-runner:latest",
+            },
+        )
+
+    assert result.success is True
+    assert len(progress.calls) == 1
+    cmd = progress.calls[0]["cmd"]
+    cmd_str = " ".join(cmd)
+    assert "build" in cmd
+    assert "-t" in cmd
+    assert "oss-crs-runner:test-crs-lsp-deadbeef99" in cmd
+    assert "--build-context" in cmd
+    assert "libcrs=" in cmd_str
+    assert "--build-arg" in cmd
+    assert "crs_version=1.2.3" in cmd_str
+    assert "target_base_image=proj:deadbeef99" in cmd_str
+    assert "base_runner_image=base-runner:latest" in cmd_str
+
+
+def test_prepare_run_images_builds_target_independent_modules(tmp_path):
+    """prepare builds target-independent run images via the derived tag."""
+    crs = _make_run_module_crs(tmp_path, target_dependent=False)
+    progress = _CaptureProgress()
+
+    with patch("oss_crs.src.crs.subprocess.run", return_value=MagicMock(returncode=1)):
+        result = crs._CRS__prepare_run_images(progress)
+
+    assert result.success is True
+    assert len(progress.calls) == 1
+    cmd_str = " ".join(progress.calls[0]["cmd"])
+    assert "oss-crs-runner:test-crs-lsp" in cmd_str
+
+
+def test_prepare_run_images_skips_target_dependent_modules(tmp_path):
+    """prepare does not build target-dependent modules (build-target owns them)."""
+    crs = _make_run_module_crs(tmp_path, target_dependent=True)
+    progress = _CaptureProgress()
+
+    result = crs._CRS__prepare_run_images(progress)
+
+    assert result.success is True
+    assert len(progress.calls) == 0
+
+
+def test_target_dependent_run_modules_selects_flagged_module(tmp_path):
+    """Only target_dependent: true modules are build-target work."""
+    crs = _make_run_module_crs(tmp_path, target_dependent=True)
+    modules = crs._CRS__target_dependent_run_modules()
+    assert [name for name, _ in modules] == ["lsp"]
+
+
+def test_target_dependent_run_modules_excludes_default_modules(tmp_path):
+    """Default (target-independent) run modules are built by prepare."""
+    crs = _make_run_module_crs(tmp_path, target_dependent=False)
+    assert crs._CRS__target_dependent_run_modules() == []
+    independent = crs._CRS__target_independent_run_modules()
+    assert [name for name, _ in independent] == ["lsp"]

--- a/oss_crs/tests/unit/test_infra_sidecar_images.py
+++ b/oss_crs/tests/unit/test_infra_sidecar_images.py
@@ -1,0 +1,375 @@
+"""Unit tests for prepare-time building of the shared infra sidecar images.
+
+The exchange, lifecycle and builder/runner sidecars are target- and
+CRS-module-independent singletons. ``CRSCompose.__prepare_oss_crs_infra``
+builds them once with stable tags so the run phase reuses them instead of
+rebuilding per run. These tests verify the build is driven for every
+registered image and that a build failure is surfaced -- without invoking
+real Docker.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from oss_crs.src.constants import (
+    ALPINE_IMAGE,
+    OSS_CRS_INFRA_SIDECAR_IMAGES,
+    OSS_CRS_INTERNAL_LLM_IMAGES,
+    OSS_CRS_INTERNAL_LLM_SIDECAR_IMAGES,
+)
+from oss_crs.src.crs_compose import CRSCompose, _lifecycle_needed
+from oss_crs.src.ui import TaskResult
+
+
+def _fake_crs(*, is_bug_fixing, is_bug_fixing_ensemble, dockerfiles=("d.Dockerfile",)):
+    """Build a minimal CRS stand-in for lifecycle-need predicate tests."""
+    modules = {
+        f"m{i}": SimpleNamespace(dockerfile=df) for i, df in enumerate(dockerfiles)
+    }
+    return SimpleNamespace(
+        config=SimpleNamespace(
+            is_bug_fixing=is_bug_fixing,
+            is_bug_fixing_ensemble=is_bug_fixing_ensemble,
+            crs_run_phase=SimpleNamespace(modules=modules),
+        )
+    )
+
+
+# A CRS topology that *does* require the lifecycle sidecar: a bug-fix ensemble
+# plus a non-ensemble bug-fixing CRS with a run-phase module to watch.
+_LIFECYCLE_CRS_LIST = [
+    _fake_crs(is_bug_fixing=True, is_bug_fixing_ensemble=True),
+    _fake_crs(is_bug_fixing=True, is_bug_fixing_ensemble=False),
+]
+# Number of base sidecars built when lifecycle is/ isn't needed.
+_BASE_WITH_LIFECYCLE = len(OSS_CRS_INFRA_SIDECAR_IMAGES)
+_BASE_WITHOUT_LIFECYCLE = len(OSS_CRS_INFRA_SIDECAR_IMAGES) - 1
+
+
+def _build_infra_sidecar_images():
+    """Invoke the name-mangled private method on a minimal fake instance.
+
+    ``__build_infra_sidecar_images`` reads nothing off ``self``, so a bare
+    stand-in is sufficient.
+    """
+    return CRSCompose._CRSCompose__build_infra_sidecar_images(SimpleNamespace())
+
+
+def _pull_internal_llm_images():
+    """Invoke the internal-LLM prefetch on a minimal fake instance."""
+    return CRSCompose._CRSCompose__pull_internal_llm_images(SimpleNamespace())
+
+
+def _pull_cleanup_image():
+    """Invoke the alpine cleanup-image prefetch on a minimal fake instance."""
+    return CRSCompose._CRSCompose__pull_cleanup_image(SimpleNamespace())
+
+
+def _prepare_oss_crs_infra(mode: str, exists: bool = True, crs_list=None):
+    """Invoke ``__prepare_oss_crs_infra`` with a faked LLM mode + CRS list."""
+    fake = SimpleNamespace(
+        llm=SimpleNamespace(mode=mode, exists=lambda: exists),
+        crs_list=crs_list if crs_list is not None else [],
+    )
+    # The method dispatches to the (name-mangled) helpers on self; bind the real
+    # implementations to the stand-in instance. The build helper may be called
+    # with an explicit registry (needed base set / internal-LLM sidecars), so
+    # the stand-in must forward positional args.
+    fake._CRSCompose__build_infra_sidecar_images = lambda *a: (
+        CRSCompose._CRSCompose__build_infra_sidecar_images(fake, *a)
+    )
+    fake._CRSCompose__needed_infra_sidecar_images = lambda: (
+        CRSCompose._CRSCompose__needed_infra_sidecar_images(fake)
+    )
+    fake._CRSCompose__pull_internal_llm_images = lambda: (
+        CRSCompose._CRSCompose__pull_internal_llm_images(fake)
+    )
+    fake._CRSCompose__pull_cleanup_image = lambda: (
+        CRSCompose._CRSCompose__pull_cleanup_image(fake)
+    )
+    # The oss-crs-deps image build shells out to a real ``docker build`` and is
+    # exercised separately; stub it to a success here so prepare proceeds.
+    fake._CRSCompose__build_oss_crs_deps = lambda: TaskResult(success=True)
+    return CRSCompose._CRSCompose__prepare_oss_crs_infra(fake)
+
+
+def test_builds_every_registered_sidecar_image_with_stable_tag():
+    """Each registered sidecar image is built with its stable tag + context."""
+    calls = []
+
+    def fake_run(cmd, **_kwargs):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0, stderr="")
+
+    with patch("oss_crs.src.crs_compose.subprocess.run", fake_run):
+        result = _build_infra_sidecar_images()
+
+    assert result.success is True
+    # One `docker build -t <tag> <context>` per registered image.
+    assert len(calls) == len(OSS_CRS_INFRA_SIDECAR_IMAGES)
+    built_tags = {cmd[cmd.index("-t") + 1] for cmd in calls}
+    assert built_tags == set(OSS_CRS_INFRA_SIDECAR_IMAGES.values())
+    for cmd in calls:
+        assert cmd[:3] == ["docker", "build", "-t"]
+        tag = cmd[cmd.index("-t") + 1]
+        context = cmd[-1]
+        # Context path ends with the subdir registered for this tag.
+        subdir = next(sd for sd, t in OSS_CRS_INFRA_SIDECAR_IMAGES.items() if t == tag)
+        assert context.endswith(f"oss-crs-infra/{subdir}")
+
+
+def test_build_failure_is_surfaced():
+    """A failing docker build aborts and returns the error output."""
+
+    def fake_run(cmd, **_kwargs):
+        return SimpleNamespace(returncode=1, stderr="boom")
+
+    with patch("oss_crs.src.crs_compose.subprocess.run", fake_run):
+        result = _build_infra_sidecar_images()
+
+    assert result.success is False
+    assert "boom" in (result.error or "")
+
+
+def test_build_stops_at_first_failure():
+    """The build short-circuits on the first failing image."""
+    calls = []
+
+    def fake_run(cmd, **_kwargs):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=1, stderr="boom")
+
+    with patch("oss_crs.src.crs_compose.subprocess.run", fake_run):
+        result = _build_infra_sidecar_images()
+
+    assert result.success is False
+    assert len(calls) == 1
+
+
+def test_internal_llm_images_are_pulled_with_pinned_digests():
+    """Each internal LLM image is pulled by its pinned digest, then tagged."""
+    calls = []
+
+    def fake_run(cmd, **_kwargs):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0, stderr="")
+
+    with patch("oss_crs.src.crs_compose.subprocess.run", fake_run):
+        result = _pull_internal_llm_images()
+
+    assert result.success is True
+    # One `docker pull <digest>` plus one `docker tag <digest> <local>` per image.
+    pulls = [cmd for cmd in calls if cmd[:2] == ["docker", "pull"]]
+    tags = [cmd for cmd in calls if cmd[:2] == ["docker", "tag"]]
+    assert len(pulls) == len(OSS_CRS_INTERNAL_LLM_IMAGES)
+    assert len(tags) == len(OSS_CRS_INTERNAL_LLM_IMAGES)
+    pulled = {cmd[-1] for cmd in pulls}
+    assert pulled == set(OSS_CRS_INTERNAL_LLM_IMAGES)
+    # Each pinned digest is tagged with its registered stable local tag.
+    tagged = {(cmd[-2], cmd[-1]) for cmd in tags}
+    assert tagged == set(OSS_CRS_INTERNAL_LLM_IMAGES.items())
+
+
+def test_internal_llm_tag_failure_is_surfaced():
+    """A failing docker tag after a successful pull is surfaced."""
+
+    def fake_run(cmd, **_kwargs):
+        if cmd[:2] == ["docker", "tag"]:
+            return SimpleNamespace(returncode=1, stderr="tag boom")
+        return SimpleNamespace(returncode=0, stderr="")
+
+    with patch("oss_crs.src.crs_compose.subprocess.run", fake_run):
+        result = _pull_internal_llm_images()
+
+    assert result.success is False
+    assert "tag boom" in (result.error or "")
+
+
+def test_internal_llm_pull_failure_is_surfaced():
+    """A failing docker pull aborts and returns the error output."""
+
+    def fake_run(cmd, **_kwargs):
+        return SimpleNamespace(returncode=1, stderr="pull boom")
+
+    with patch("oss_crs.src.crs_compose.subprocess.run", fake_run):
+        result = _pull_internal_llm_images()
+
+    assert result.success is False
+    assert "pull boom" in (result.error or "")
+
+
+def test_cleanup_image_is_pulled_by_digest_and_tagged_alpine():
+    """The alpine cleanup image is pulled by its pinned digest, then tagged."""
+    calls = []
+
+    def fake_run(cmd, **_kwargs):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0, stderr="")
+
+    with patch("oss_crs.src.crs_compose.subprocess.run", fake_run):
+        result = _pull_cleanup_image()
+
+    assert result.success is True
+    # One `docker pull <digest>` and one `docker tag <digest> alpine`.
+    assert calls == [
+        ["docker", "pull", ALPINE_IMAGE],
+        ["docker", "tag", ALPINE_IMAGE, "alpine"],
+    ]
+
+
+def test_cleanup_image_pull_failure_is_surfaced():
+    """A failing docker pull of the cleanup image aborts with its error."""
+
+    def fake_run(cmd, **_kwargs):
+        return SimpleNamespace(returncode=1, stderr="pull boom")
+
+    with patch("oss_crs.src.crs_compose.subprocess.run", fake_run):
+        result = _pull_cleanup_image()
+
+    assert result.success is False
+    assert "pull boom" in (result.error or "")
+
+
+def test_cleanup_image_tag_failure_is_surfaced():
+    """A failing docker tag after a successful pull is surfaced."""
+
+    def fake_run(cmd, **_kwargs):
+        if cmd[:2] == ["docker", "tag"]:
+            return SimpleNamespace(returncode=1, stderr="tag boom")
+        return SimpleNamespace(returncode=0, stderr="")
+
+    with patch("oss_crs.src.crs_compose.subprocess.run", fake_run):
+        result = _pull_cleanup_image()
+
+    assert result.success is False
+    assert "tag boom" in (result.error or "")
+
+
+def test_prepare_pulls_internal_llm_images_only_in_internal_mode():
+    """Internal-mode prepare builds needed sidecars then pulls the LLM images."""
+    calls = []
+
+    def fake_run(cmd, **_kwargs):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0, stderr="")
+
+    with patch("oss_crs.src.crs_compose.subprocess.run", fake_run):
+        result = _prepare_oss_crs_infra(mode="internal", crs_list=_LIFECYCLE_CRS_LIST)
+
+    assert result.success is True
+    verbs = [cmd[1] for cmd in calls]
+    # All base sidecars (lifecycle needed here) + the internal-LLM sidecar.
+    assert verbs.count("build") == (
+        _BASE_WITH_LIFECYCLE + len(OSS_CRS_INTERNAL_LLM_SIDECAR_IMAGES)
+    )
+    # The internal-LLM digests plus the unconditional alpine cleanup pull.
+    assert verbs.count("pull") == len(OSS_CRS_INTERNAL_LLM_IMAGES) + 1
+    pulled = {cmd[-1] for cmd in calls if cmd[1] == "pull"}
+    assert pulled == set(OSS_CRS_INTERNAL_LLM_IMAGES) | {ALPINE_IMAGE}
+    # The internal-LLM sidecar is built with its stable tag.
+    built_tags = {cmd[cmd.index("-t") + 1] for cmd in calls if cmd[1] == "build"}
+    assert set(OSS_CRS_INTERNAL_LLM_SIDECAR_IMAGES.values()) <= built_tags
+
+
+def test_prepare_skips_llm_pull_in_external_mode():
+    """External (or disabled) LLM mode builds only the needed base sidecars.
+
+    The alpine cleanup image is still pulled (unconditionally), but no
+    internal-LLM images are pulled.
+    """
+    calls = []
+
+    def fake_run(cmd, **_kwargs):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0, stderr="")
+
+    with patch("oss_crs.src.crs_compose.subprocess.run", fake_run):
+        result = _prepare_oss_crs_infra(mode="external", crs_list=_LIFECYCLE_CRS_LIST)
+
+    assert result.success is True
+    # Only the alpine cleanup image is pulled; no internal-LLM digests.
+    pulled = {cmd[-1] for cmd in calls if cmd[:2] == ["docker", "pull"]}
+    assert pulled == {ALPINE_IMAGE}
+    verbs = [cmd[1] for cmd in calls]
+    # Only base sidecars build; the internal-LLM sidecar is skipped.
+    assert verbs.count("build") == _BASE_WITH_LIFECYCLE
+    built_tags = {cmd[cmd.index("-t") + 1] for cmd in calls if cmd[1] == "build"}
+    assert set(OSS_CRS_INTERNAL_LLM_SIDECAR_IMAGES.values()).isdisjoint(built_tags)
+
+
+def test_prepare_skips_llm_pull_when_disabled():
+    """When the LLM stack is disabled, prepare pulls only the cleanup image."""
+    calls = []
+
+    def fake_run(cmd, **_kwargs):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0, stderr="")
+
+    with patch("oss_crs.src.crs_compose.subprocess.run", fake_run):
+        result = _prepare_oss_crs_infra(
+            mode="disabled", exists=False, crs_list=_LIFECYCLE_CRS_LIST
+        )
+
+    assert result.success is True
+    pulled = {cmd[-1] for cmd in calls if cmd[:2] == ["docker", "pull"]}
+    assert pulled == {ALPINE_IMAGE}
+    verbs = [cmd[1] for cmd in calls]
+    assert verbs.count("build") == _BASE_WITH_LIFECYCLE
+
+
+def test_prepare_skips_lifecycle_build_when_not_needed():
+    """A config with no bug-fix ensemble does not build the lifecycle sidecar."""
+    calls = []
+
+    def fake_run(cmd, **_kwargs):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0, stderr="")
+
+    crs_list = [_fake_crs(is_bug_fixing=True, is_bug_fixing_ensemble=False)]
+    with patch("oss_crs.src.crs_compose.subprocess.run", fake_run):
+        result = _prepare_oss_crs_infra(mode="external", crs_list=crs_list)
+
+    assert result.success is True
+    verbs = [cmd[1] for cmd in calls]
+    assert verbs.count("build") == _BASE_WITHOUT_LIFECYCLE
+    built_tags = {cmd[cmd.index("-t") + 1] for cmd in calls if cmd[1] == "build"}
+    assert OSS_CRS_INFRA_SIDECAR_IMAGES["lifecycle"] not in built_tags
+
+
+# ---------------------------------------------------------------------------
+# _lifecycle_needed predicate
+# ---------------------------------------------------------------------------
+
+
+def test_lifecycle_not_needed_for_empty_config():
+    assert _lifecycle_needed([]) is False
+
+
+def test_lifecycle_not_needed_without_bug_fix_ensemble():
+    crs_list = [
+        _fake_crs(is_bug_fixing=True, is_bug_fixing_ensemble=False),
+        _fake_crs(is_bug_fixing=False, is_bug_fixing_ensemble=False),
+    ]
+    assert _lifecycle_needed(crs_list) is False
+
+
+def test_lifecycle_not_needed_with_ensemble_but_no_watchable_crs():
+    # Only the ensemble CRS is present; nothing for lifecycle to watch.
+    crs_list = [_fake_crs(is_bug_fixing=True, is_bug_fixing_ensemble=True)]
+    assert _lifecycle_needed(crs_list) is False
+
+
+def test_lifecycle_not_needed_when_watchable_crs_has_no_module():
+    crs_list = [
+        _fake_crs(is_bug_fixing=True, is_bug_fixing_ensemble=True),
+        _fake_crs(is_bug_fixing=True, is_bug_fixing_ensemble=False, dockerfiles=()),
+    ]
+    assert _lifecycle_needed(crs_list) is False
+
+
+def test_lifecycle_needed_with_ensemble_and_watchable_crs():
+    crs_list = [
+        _fake_crs(is_bug_fixing=True, is_bug_fixing_ensemble=True),
+        _fake_crs(is_bug_fixing=True, is_bug_fixing_ensemble=False),
+    ]
+    assert _lifecycle_needed(crs_list) is True

--- a/oss_crs/tests/unit/test_offline_flag.py
+++ b/oss_crs/tests/unit/test_offline_flag.py
@@ -1,4 +1,4 @@
-"""Tests for the --offline flag that disables git fetch on CRS repos.
+"""Unit tests for the --offline flag
 
 The flag controls how ``init_crs_repo`` initializes a CRS source checkout:
 
@@ -12,15 +12,56 @@ The flag controls how ``init_crs_repo`` initializes a CRS source checkout:
 These tests verify the branch selection without invoking real git, plus
 that the flag is forwarded from the CLI/compose layers down to
 ``init_crs_repo``.
+
+A separate group of tests covers the ``offline`` behavior in
+``CRSCompose.__prepare_local_running_env``: when offline, the
+"Build docker images" task must be skipped (relying on pre-existing local
+images) while all other preparation tasks are still scheduled.
 """
 
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
-from oss_crs.src.config.crs_compose import CRSEntry, CRSSource
 from oss_crs.src.crs import init_crs_repo
+from oss_crs.src.crs_compose import CRSCompose
 from oss_crs.src.ui import TaskResult
+
+
+class _FakeMultiTaskProgress:
+    """Progress double that records scheduled task names and notes.
+
+    It supports both ways production code drives a ``MultiTaskProgress``:
+
+    - tasks supplied to the constructor (``MultiTaskProgress(tasks, ...)``), as
+      ``init_crs_repo`` does; and
+    - tasks/notes added on an injected instance via ``add_task``/``add_note``,
+      as ``CRSCompose.__prepare_local_running_env`` does.
+
+    Task callables are never executed, so this only captures *what* was
+    scheduled, not its side effects.
+    """
+
+    def __init__(self, tasks=None, title=None, **kwargs):
+        self.task_names: list[str] = [name for name, _ in (tasks or [])]
+        self.notes: list[str] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def add_task(self, name, func):
+        self.task_names.append(name)
+
+    def add_note(self, note):
+        self.notes.append(note)
+
+    def run_added_tasks(self, *args, **kwargs):
+        return TaskResult(success=True)
 
 
 @pytest.fixture
@@ -35,20 +76,16 @@ def scheduled():
     """
     names: list[str] = []
 
-    class _FakeMultiTaskProgress:
-        def __init__(self, tasks, title=None, **kwargs):
-            names.extend(name for name, _ in tasks)
+    class _Tracking(_FakeMultiTaskProgress):
+        def __init__(self, tasks=None, **kwargs):
+            super().__init__(tasks=tasks, **kwargs)
+            names.extend(self.task_names)
 
-        def __enter__(self):
-            return self
+        def add_task(self, name, func):
+            super().add_task(name, func)
+            names.append(name)
 
-        def __exit__(self, *exc):
-            return False
-
-        def run_added_tasks(self, *args, **kwargs):
-            return TaskResult(success=True)
-
-    with patch("oss_crs.src.crs.MultiTaskProgress", _FakeMultiTaskProgress):
+    with patch("oss_crs.src.crs.MultiTaskProgress", _Tracking):
         yield names
 
 
@@ -74,7 +111,7 @@ def test_offline_existing_repo_resets_without_fetch(tmp_path, scheduled):
     dest = tmp_path / "crs_src" / "test-crs"
     dest.mkdir(parents=True)
 
-    result = init_crs_repo(
+    init_crs_repo(
         name="test-crs",
         repo_url="https://example.com/test-crs.git",
         branch="main",
@@ -82,7 +119,6 @@ def test_offline_existing_repo_resets_without_fetch(tmp_path, scheduled):
         offline=True,
     )
 
-    assert result.success is True
     assert scheduled == ["Git Reset"]
 
 
@@ -91,7 +127,7 @@ def test_online_existing_repo_fetches_and_resets(tmp_path, scheduled):
     dest = tmp_path / "crs_src" / "test-crs"
     dest.mkdir(parents=True)
 
-    result = init_crs_repo(
+    init_crs_repo(
         name="test-crs",
         repo_url="https://example.com/test-crs.git",
         branch="main",
@@ -99,7 +135,6 @@ def test_online_existing_repo_fetches_and_resets(tmp_path, scheduled):
         offline=False,
     )
 
-    assert result.success is True
     assert scheduled == ["Git Fetch", "Git Reset"]
 
 
@@ -107,7 +142,7 @@ def test_online_missing_repo_clones(tmp_path, scheduled):
     """Without offline, a missing checkout is cloned."""
     dest = tmp_path / "crs_src" / "test-crs"  # does not exist
 
-    result = init_crs_repo(
+    init_crs_repo(
         name="test-crs",
         repo_url="https://example.com/test-crs.git",
         branch="main",
@@ -115,7 +150,6 @@ def test_online_missing_repo_clones(tmp_path, scheduled):
         offline=False,
     )
 
-    assert result.success is True
     assert scheduled == ["Cloning CRS repository"]
 
 
@@ -123,14 +157,13 @@ def test_offline_defaults_to_false(tmp_path, scheduled):
     """offline is opt-in: the default behavior still clones a missing repo."""
     dest = tmp_path / "crs_src" / "test-crs"  # does not exist
 
-    result = init_crs_repo(
+    init_crs_repo(
         name="test-crs",
         repo_url="https://example.com/test-crs.git",
         branch="main",
         dest_path=dest,
     )
 
-    assert result.success is True
     assert scheduled == ["Cloning CRS repository"]
 
 
@@ -139,7 +172,7 @@ def test_skip_if_exists_short_circuits_before_offline_check(tmp_path, scheduled)
     dest = tmp_path / "crs_src" / "test-crs"
     dest.mkdir(parents=True)
 
-    result = init_crs_repo(
+    init_crs_repo(
         name="test-crs",
         repo_url="https://example.com/test-crs.git",
         branch="main",
@@ -148,6 +181,51 @@ def test_skip_if_exists_short_circuits_before_offline_check(tmp_path, scheduled)
         offline=True,
     )
 
-    assert result.success is True
     # No reset/fetch/clone scheduled at all.
     assert scheduled == []
+
+
+# ---------------------------------------------------------------------------
+# offline build-skip in CRSCompose.__prepare_local_running_env
+# ---------------------------------------------------------------------------
+
+
+def _prepare_local_running_env(offline: bool, tmp_path: Path):
+    """Invoke the (name-mangled) private method on a minimal fake instance.
+
+    Only ``self.offline`` is read during task scheduling; every other ``self``
+    access lives inside task closures that are never executed by the recording
+    progress double, so a lightweight stand-in is sufficient.
+    """
+    fake_self = SimpleNamespace(offline=offline)
+    tmp_docker_compose = SimpleNamespace(
+        docker_compose=tmp_path / "docker-compose.yaml"
+    )
+    progress = _FakeMultiTaskProgress()
+
+    result = CRSCompose._CRSCompose__prepare_local_running_env(
+        fake_self,
+        project_name="proj",
+        target=SimpleNamespace(),
+        tmp_docker_compose=tmp_docker_compose,
+        run_id="run-id",
+        build_id="build-id",
+        sanitizer="address",
+        progress=progress,
+    )
+    return result, progress
+
+
+_BUILD_TASK = "Build docker images in the combined docker compose file"
+
+
+def test_online_schedules_docker_build(tmp_path):
+    """Without offline, the docker image build task is scheduled."""
+    _, progress = _prepare_local_running_env(offline=False, tmp_path=tmp_path)
+    assert _BUILD_TASK in progress.task_names
+
+
+def test_offline_skips_docker_build(tmp_path):
+    """With offline, the docker image build task is skipped."""
+    _, progress = _prepare_local_running_env(offline=True, tmp_path=tmp_path)
+    assert _BUILD_TASK not in progress.task_names

--- a/oss_crs/tests/unit/test_offline_flag.py
+++ b/oss_crs/tests/unit/test_offline_flag.py
@@ -1,0 +1,153 @@
+"""Tests for the --offline flag that disables git fetch on CRS repos.
+
+The flag controls how ``init_crs_repo`` initializes a CRS source checkout:
+
+  | offline | repo exists | behavior                         |
+  |---------|-------------|----------------------------------|
+  | True    | no          | hard error (cannot fetch/clone)  |
+  | True    | yes         | git reset only (no fetch)        |
+  | False   | yes         | git fetch + git reset            |
+  | False   | no          | git clone                        |
+
+These tests verify the branch selection without invoking real git, plus
+that the flag is forwarded from the CLI/compose layers down to
+``init_crs_repo``.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from oss_crs.src.config.crs_compose import CRSEntry, CRSSource
+from oss_crs.src.crs import init_crs_repo
+from oss_crs.src.ui import TaskResult
+
+
+@pytest.fixture
+def scheduled():
+    """Patch MultiTaskProgress and yield the list of task names scheduled.
+
+    ``init_crs_repo`` builds a list of (name, callable) tasks and runs them via
+    ``MultiTaskProgress(tasks, ...).run_added_tasks()``. The fake records the
+    task names into a fresh per-test list, so tests can assert which git
+    operations were scheduled without running real git. An empty list means no
+    tasks were scheduled at all.
+    """
+    names: list[str] = []
+
+    class _FakeMultiTaskProgress:
+        def __init__(self, tasks, title=None, **kwargs):
+            names.extend(name for name, _ in tasks)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def run_added_tasks(self, *args, **kwargs):
+            return TaskResult(success=True)
+
+    with patch("oss_crs.src.crs.MultiTaskProgress", _FakeMultiTaskProgress):
+        yield names
+
+
+def test_offline_missing_repo_returns_failure(tmp_path, scheduled):
+    """offline + missing checkout fails without scheduling any git task."""
+    dest = tmp_path / "crs_src" / "test-crs"  # does not exist
+
+    result = init_crs_repo(
+        name="test-crs",
+        repo_url="https://example.com/test-crs.git",
+        branch="main",
+        dest_path=dest,
+        offline=True,
+    )
+
+    assert result.success is False
+    # No git tasks should have been scheduled.
+    assert scheduled == []
+
+
+def test_offline_existing_repo_resets_without_fetch(tmp_path, scheduled):
+    """offline + existing checkout resets to origin but never fetches."""
+    dest = tmp_path / "crs_src" / "test-crs"
+    dest.mkdir(parents=True)
+
+    result = init_crs_repo(
+        name="test-crs",
+        repo_url="https://example.com/test-crs.git",
+        branch="main",
+        dest_path=dest,
+        offline=True,
+    )
+
+    assert result.success is True
+    assert scheduled == ["Git Reset"]
+
+
+def test_online_existing_repo_fetches_and_resets(tmp_path, scheduled):
+    """Without offline, an existing checkout fetches then resets."""
+    dest = tmp_path / "crs_src" / "test-crs"
+    dest.mkdir(parents=True)
+
+    result = init_crs_repo(
+        name="test-crs",
+        repo_url="https://example.com/test-crs.git",
+        branch="main",
+        dest_path=dest,
+        offline=False,
+    )
+
+    assert result.success is True
+    assert scheduled == ["Git Fetch", "Git Reset"]
+
+
+def test_online_missing_repo_clones(tmp_path, scheduled):
+    """Without offline, a missing checkout is cloned."""
+    dest = tmp_path / "crs_src" / "test-crs"  # does not exist
+
+    result = init_crs_repo(
+        name="test-crs",
+        repo_url="https://example.com/test-crs.git",
+        branch="main",
+        dest_path=dest,
+        offline=False,
+    )
+
+    assert result.success is True
+    assert scheduled == ["Cloning CRS repository"]
+
+
+def test_offline_defaults_to_false(tmp_path, scheduled):
+    """offline is opt-in: the default behavior still clones a missing repo."""
+    dest = tmp_path / "crs_src" / "test-crs"  # does not exist
+
+    result = init_crs_repo(
+        name="test-crs",
+        repo_url="https://example.com/test-crs.git",
+        branch="main",
+        dest_path=dest,
+    )
+
+    assert result.success is True
+    assert scheduled == ["Cloning CRS repository"]
+
+
+def test_skip_if_exists_short_circuits_before_offline_check(tmp_path, scheduled):
+    """skip_if_exists wins over offline: an existing repo is left untouched."""
+    dest = tmp_path / "crs_src" / "test-crs"
+    dest.mkdir(parents=True)
+
+    result = init_crs_repo(
+        name="test-crs",
+        repo_url="https://example.com/test-crs.git",
+        branch="main",
+        dest_path=dest,
+        skip_if_exists=True,
+        offline=True,
+    )
+
+    assert result.success is True
+    # No reset/fetch/clone scheduled at all.
+    assert scheduled == []

--- a/oss_crs/tests/unit/test_renderer_run_compose.py
+++ b/oss_crs/tests/unit/test_renderer_run_compose.py
@@ -63,6 +63,7 @@ def _make_crs(
     """
     module_config = SimpleNamespace(
         dockerfile="patcher.Dockerfile",
+        target_dependent=False,
         additional_env={},
     )
     config = SimpleNamespace(
@@ -109,6 +110,7 @@ def _make_target(
     return SimpleNamespace(
         get_target_env=lambda: {"harness": harness},
         get_docker_image_name=lambda: image_name,
+        get_repo_hash=lambda: image_name.rsplit(":", 1)[-1],
         base_runner_image="gcr.io/oss-fuzz-base/base-runner:ubuntu-24-04",
         proj_path=tmp_path / "proj",
         repo_path=tmp_path / "repo",
@@ -128,10 +130,15 @@ def _render(crs_compose, target, tmp_path: Path):
     )
 
 
-def test_runner_module_receives_base_runner_image_build_arg(
+def test_target_independent_module_renders_consume_only_image(
     monkeypatch, tmp_path: Path
 ) -> None:
-    """Runner build args carry the OS-matched base-runner image (issue #101)."""
+    """A default (target_dependent: false) run module is consume-only.
+
+    The run compose references the prepare-built image by its framework-derived
+    tag (``oss-crs-runner:<crs>-<module>``) and emits no ``build:`` block; the
+    base-runner build arg is applied at build time, not at run time.
+    """
     _patch_renderer(monkeypatch)
 
     crs = _make_crs(tmp_path, "crs-libfuzzer")
@@ -140,13 +147,9 @@ def test_runner_module_receives_base_runner_image_build_arg(
 
     rendered, _ = _render(crs_compose, target, tmp_path)
 
-    build_args = yaml.safe_load(rendered)["services"]["crs-libfuzzer_patcher"]["build"][
-        "args"
-    ]
-    assert "target_base_image=memcached:abc123" in build_args
-    assert (
-        "base_runner_image=gcr.io/oss-fuzz-base/base-runner:ubuntu-24-04" in build_args
-    )
+    service = yaml.safe_load(rendered)["services"]["crs-libfuzzer_patcher"]
+    assert service["image"] == "oss-crs-runner:crs-libfuzzer-patcher"
+    assert "build" not in service
 
 
 def test_single_bug_fixing_run_keeps_fetch_mount_and_exchange_sidecar(
@@ -185,6 +188,39 @@ def test_single_bug_fixing_run_keeps_fetch_mount_and_exchange_sidecar(
     # Always-on sidecar services (CFG-03)
     assert "oss-crs-builder-sidecar" in services
     assert "oss-crs-runner-sidecar" in services
+
+
+def test_infra_sidecars_use_stable_run_independent_image_tags(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Infra sidecars reference stable, run-independent image tags.
+
+    The tags must not embed the per-run project name, so that images built
+    once at prepare time are reused across runs (and offline runs find them).
+    """
+    from oss_crs.src.constants import OSS_CRS_INFRA_SIDECAR_IMAGES
+
+    _patch_renderer(monkeypatch)
+
+    crs = _make_crs(tmp_path, "crs-codex")
+    crs_compose = _make_crs_compose(tmp_path, [crs])
+    target = _make_target(tmp_path, has_repo=False)
+
+    rendered, _warnings = _render(crs_compose, target, tmp_path)
+    services = yaml.safe_load(rendered)["services"]
+
+    expected = OSS_CRS_INFRA_SIDECAR_IMAGES
+    assert services["oss-crs-exchange"]["image"] == expected["exchange"]
+    assert services["oss-crs-builder-sidecar"]["image"] == expected["builder-sidecar"]
+    assert services["oss-crs-runner-sidecar"]["image"] == expected["runner-sidecar"]
+
+    # None of the infra sidecar tags embed the per-run project name ("proj").
+    for svc in (
+        "oss-crs-exchange",
+        "oss-crs-builder-sidecar",
+        "oss-crs-runner-sidecar",
+    ):
+        assert "proj" not in services[svc]["image"]
 
 
 @pytest.mark.parametrize(
@@ -321,6 +357,7 @@ def _make_triage_crs(tmp_path: Path, name: str) -> SimpleNamespace:
 
     module_config = SimpleNamespace(
         dockerfile="triage.Dockerfile",
+        target_dependent=False,
         additional_env={},
     )
     config = SimpleNamespace(
@@ -349,6 +386,7 @@ def _make_bug_finding_crs(tmp_path: Path, name: str) -> SimpleNamespace:
 
     module_config = SimpleNamespace(
         dockerfile="finder.Dockerfile",
+        target_dependent=False,
         additional_env={},
     )
     config = SimpleNamespace(
@@ -670,3 +708,80 @@ def test_compose06_fetch_dir_per_type_routing_with_triage_only(
     assert any(
         f"{exchange}/seeds:/OSS_CRS_FETCH_DIR/seeds:ro" == v for v in finder_volumes
     ), f"finder must mount raw seeds; got: {finder_volumes}"
+
+
+# ---------------------------------------------------------------------------
+# Consume-only run images: modules render `image:` and never a `build:` block
+# ---------------------------------------------------------------------------
+
+
+def _make_run_module_crs(
+    tmp_path: Path, name: str, *, target_dependent: bool
+) -> SimpleNamespace:
+    """A bug-finding CRS with a single consume-only run module."""
+    from oss_crs.src.config.crs import CRSType
+
+    module_config = SimpleNamespace(
+        dockerfile="lsp.Dockerfile",
+        target_dependent=target_dependent,
+        additional_env={},
+    )
+    config = SimpleNamespace(
+        version="1.0",
+        type=[CRSType.BUG_FINDING],
+        is_bug_fixing=False,
+        is_bug_fixing_ensemble=False,
+        is_triage=False,
+        is_seed_filter=False,
+        crs_run_phase=SimpleNamespace(modules={"lsp": module_config}),
+        target_build_phase=None,
+    )
+    return SimpleNamespace(
+        name=name,
+        crs_path=tmp_path,
+        resource=SimpleNamespace(
+            cpuset="2-7", memory="8G", additional_env={}, llm_budget=1
+        ),
+        config=config,
+    )
+
+
+def test_target_dependent_module_renders_hashed_image_no_build(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """A target_dependent module references the build-target image by hash.
+
+    The framework-derived tag embeds the target's repo hash so the rendered tag
+    matches what the build-target phase produced; no ``build:`` block is emitted.
+    """
+    _patch_renderer(monkeypatch)
+
+    crs = _make_run_module_crs(tmp_path, "crs-shelley", target_dependent=True)
+    crs_compose = _make_crs_compose(tmp_path, [crs])
+    # repo hash is the part after ':' in the docker image name.
+    target = _make_target(tmp_path, image_name="proj:deadbeef99")
+
+    rendered, warnings = _render(crs_compose, target, tmp_path)
+    assert warnings == []
+
+    service = yaml.safe_load(rendered)["services"]["crs-shelley_lsp"]
+    assert service["image"] == "oss-crs-runner:crs-shelley-lsp-deadbeef99"
+    assert "build" not in service
+
+
+def test_target_independent_module_renders_unhashed_image_no_build(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """A default module references the prepare image (no target hash)."""
+    _patch_renderer(monkeypatch)
+
+    crs = _make_run_module_crs(tmp_path, "crs-shelley", target_dependent=False)
+    crs_compose = _make_crs_compose(tmp_path, [crs])
+    target = _make_target(tmp_path, image_name="proj:deadbeef99")
+
+    rendered, warnings = _render(crs_compose, target, tmp_path)
+    assert warnings == []
+
+    service = yaml.safe_load(rendered)["services"]["crs-shelley_lsp"]
+    assert service["image"] == "oss-crs-runner:crs-shelley-lsp"
+    assert "build" not in service

--- a/oss_crs/tests/unit/test_template_rendering.py
+++ b/oss_crs/tests/unit/test_template_rendering.py
@@ -8,6 +8,8 @@ import pytest
 from jinja2 import Environment, FileSystemLoader
 from pathlib import Path
 
+from oss_crs.src.constants import OSS_CRS_INFRA_SIDECAR_IMAGES
+
 
 TEMPLATES_DIR = Path(__file__).parent.parent.parent / "src" / "templates"
 
@@ -74,6 +76,7 @@ class TestMountInfrastructure:
 
         module_config = SimpleNamespace(
             dockerfile="patcher.Dockerfile",
+            target_dependent=False,
             run_snapshot=False,
             additional_env={},
         )
@@ -104,9 +107,13 @@ class TestMountInfrastructure:
             "build_id": "build-123",
             "sanitizer": "address",
             "oss_crs_infra_root_path": "/oss-crs-infra",
+            "infra_sidecar_images": OSS_CRS_INFRA_SIDECAR_IMAGES,
             "snapshot_image_tag": "",
             "resolve_dockerfile": lambda crs_path, dockerfile: (
                 str(crs_path) + "/" + str(dockerfile)
+            ),
+            "run_module_image": lambda crs_name, module_name, mc: (
+                f"oss-crs-runner:{crs_name}-{module_name}"
             ),
             "fetch_dir": "",
             "exchange_dir": "",
@@ -132,6 +139,7 @@ class TestMountInfrastructure:
 
         module_config = SimpleNamespace(
             dockerfile="patcher.Dockerfile",
+            target_dependent=False,
             run_snapshot=False,
             additional_env={},
         )
@@ -162,9 +170,13 @@ class TestMountInfrastructure:
             "build_id": "build-123",
             "sanitizer": "address",
             "oss_crs_infra_root_path": "/oss-crs-infra",
+            "infra_sidecar_images": OSS_CRS_INFRA_SIDECAR_IMAGES,
             "snapshot_image_tag": "",
             "resolve_dockerfile": lambda crs_path, dockerfile: (
                 str(crs_path) + "/" + str(dockerfile)
+            ),
+            "run_module_image": lambda crs_name, module_name, mc: (
+                f"oss-crs-runner:{crs_name}-{module_name}"
             ),
             "fetch_dir": "",
             "exchange_dir": "",
@@ -182,17 +194,94 @@ class TestMountInfrastructure:
 
         assert "/extracted/source:/OSS_CRS_TARGET_SOURCE:ro" in rendered
 
-    def test_target_source_mount_when_provided(self, jinja_env):
-        """target_source_path should render as a read-only volume mount when provided."""
-        template = jinja_env.get_template("build-target.docker-compose.yaml.j2")
-        context = _build_target_context(
-            fuzz_proj_path="/proj/test",
-            target_source_path="/home/user/source",
-        )
+    def test_litellm_key_gen_uses_stable_prepare_time_tag(self, jinja_env):
+        """In internal-LLM mode the key-gen sidecar uses the stable infra tag.
 
+        Folding litellm-key-gen into the prepare-time scheme means it is tagged
+        run-independently (``oss-crs-litellm-key-gen:latest``) instead of the
+        old per-run ``{{ crs_compose_name }}-oss-crs-litellm-key-gen:latest``.
+        """
+        from types import SimpleNamespace
+
+        from oss_crs.src.constants import OSS_CRS_INTERNAL_LLM_SIDECAR_IMAGES
+
+        template = jinja_env.get_template("run-crs-compose.docker-compose.yaml.j2")
+
+        module_config = SimpleNamespace(
+            dockerfile="patcher.Dockerfile",
+            target_dependent=False,
+            run_snapshot=False,
+            additional_env={},
+        )
+        crs = SimpleNamespace(
+            name="test-crs",
+            crs_path=Path("/crs"),
+            resource=SimpleNamespace(cpuset="0-3", memory="8G", additional_env={}),
+            config=SimpleNamespace(
+                version="1.0",
+                type=["bug-fixing"],
+                is_bug_fixing=True,
+                is_bug_fixing_ensemble=False,
+                is_triage=False,
+                is_seed_filter=False,
+                crs_run_phase=SimpleNamespace(modules={"patcher": module_config}),
+            ),
+        )
+        llm_context = SimpleNamespace(
+            mode="internal",
+            litellm_env_secret_files={},
+            litellm_config_path="/cfg/litellm.yaml",
+            key_gen_request_path="/req/key_gen_request.yaml",
+            secret_files={},
+            master_key_file="/secrets/master_key",
+            postgres_password_file="/secrets/pg_password",
+        )
+        context = {
+            "libCRS_path": "/libcrs",
+            "crs_compose_name": "crs_compose_run123",
+            "crs_list": [crs],
+            "crs_compose_env": {"type": "local"},
+            "target_env": {},
+            "target": _MockTarget(proj_path="/home/user/myproject", has_repo=False),
+            "work_dir": _MockWorkDir(),
+            "run_id": "run-123",
+            "build_id": "build-123",
+            "sanitizer": "address",
+            "oss_crs_infra_root_path": "/oss-crs-infra",
+            "infra_sidecar_images": {
+                **OSS_CRS_INFRA_SIDECAR_IMAGES,
+                **OSS_CRS_INTERNAL_LLM_SIDECAR_IMAGES,
+            },
+            "snapshot_image_tag": "",
+            "resolve_dockerfile": lambda crs_path, dockerfile: (
+                str(crs_path) + "/" + str(dockerfile)
+            ),
+            "run_module_image": lambda crs_name, module_name, mc: (
+                f"oss-crs-runner:{crs_name}-{module_name}"
+            ),
+            "fetch_dir": "",
+            "exchange_dir": "",
+            "fetch_dir_mounts": {},
+            "processed_exchange_dir": None,
+            "bug_finding_ensemble": False,
+            "bug_fix_ensemble": False,
+            "cgroup_parents": None,
+            "module_envs": {"test-crs_patcher": {}},
+            "fuzz_proj_path": "/home/user/myproject",
+            "target_source_path": "/extracted/source",
+            "llm_context": llm_context,
+            "litellm_image": "litellm@sha256:abc",
+            "postgres_image": "postgres@sha256:def",
+            "postgres_user": "crs",
+            "postgres_port": 5432,
+            "postgres_host": "postgres.oss-crs-infra-only",
+            "litellm_internal_url": "http://litellm.oss-crs:4000",
+            "litellm_spend_report_path": "/spend/litellm-spend-report.json",
+            "sidecar_env": {},
+        }
         rendered = template.render(context)
 
-        assert "/home/user/source:/OSS_CRS_TARGET_SOURCE:ro" in rendered
+        assert "image: oss-crs-litellm-key-gen:latest" in rendered
 
     def test_target_source_mount_always_present(self, jinja_env):
         """target_source_path volume mount should always appear unconditionally."""

--- a/oss_crs/tests/unit/test_ui.py
+++ b/oss_crs/tests/unit/test_ui.py
@@ -65,7 +65,6 @@ def test_docker_compose_down_prunes_project_scoped_images(monkeypatch) -> None:
                     "proj-svc1:latest\n"
                     "other:latest\n"
                     "proj-svc2:latest\n"
-                    "proj-oss-crs-litellm-key-gen:latest\n"
                     "oss-crs-litellm-key-gen:latest\n"
                 ),
                 stderr="",
@@ -79,10 +78,6 @@ def test_docker_compose_down_prunes_project_scoped_images(monkeypatch) -> None:
             if ref == "proj-svc2:latest":
                 return SimpleNamespace(
                     returncode=0, stdout="sha256:svc2 proj\n", stderr=""
-                )
-            if ref == "proj-oss-crs-litellm-key-gen:latest":
-                return SimpleNamespace(
-                    returncode=0, stdout="sha256:keygen proj\n", stderr=""
                 )
             return SimpleNamespace(
                 returncode=0, stdout="sha256:other other\n", stderr=""
@@ -131,7 +126,6 @@ def test_docker_compose_down_prunes_project_scoped_images(monkeypatch) -> None:
         "image",
         "rm",
         "-f",
-        "proj-oss-crs-litellm-key-gen:latest",
         "proj-svc-label:latest",
         "proj-svc1:latest",
         "proj-svc2:latest",


### PR DESCRIPTION
## Summary

Describe what changed and why.

Added a --offline flag:

- For all subcommands the flag prevents oss-crs from running git fetch

The jinja2 template for the run crs command is updated so that docker compose will only pull docker images from a docker registry and never build docker images. The docker image builds are then moved to the prepare/build-target steps based on whether they are target dependent: this is specified using the target_dependent field in the crs.yaml file. Prepare images built for the run phase are excluded from the run time image teardown.

Run time images which are target project independent are built/pulled during the prepare phase.
Examples: oss-crs-exchange, oss-crs-runner-sidecar, oss-crs-builder-sidecar, oss-crs-litellm-key-gen, oss-crs-litellm, oss-crs-postgres, oss-crs-lifecycle

Run time images which are target project dependent are built/pulled during the build-target phase.
Examples: lsp from atlantis-multilang-wo-concolic

Note: this pull request requires updates to the crs.yaml files upstream for atlantis-multilang-wo-concolic, specifically to set target_dependent: true for lsp.Dockerfile and lsp_builder.Dockerfile.

## User Impact

- [x] User-facing change
- [ ] Internal-only change

If user-facing, describe CLI/API/config/docs impact and migration steps.

## Release Note / Changelog

- [x] I updated `CHANGELOG.md` (`[Unreleased]`) for user-facing changes
- [ ] No changelog entry needed (internal-only refactor/test/chore)

If this PR includes deprecation or breaking behavior, include:
- replacement path for users
- planned removal version/release window

## Validation

List tests/checks run and their results.

All unit/integration tests run and passed except for resource limits tests due to absence of cgroups.

## Checklist

- [x] I followed Conventional Commits
- [x] I updated docs for behavior/config/CLI changes
- [x] I added/updated tests for behavior changes
- [x] I considered backward compatibility and migration impact
