### PR TITLE
Add support for building dependencies offline using nix

### DIFF
--- a/docs/crs-development-guide.md
+++ b/docs/crs-development-guide.md
@@ -195,6 +195,11 @@ COPY bin/compile_target /usr/local/bin/compile_target
 CMD ["compile_target"]
 ```
 
+> **Offline builds:** `install.sh` needs network access (it downloads `uv` and
+> installs `rsync`). For a fully offline build, replace the two `libCRS` lines
+> with `COPY --from=oss-crs-deps` — see the
+> [oss-crs-deps Image](design/deps-image.md) doc.
+
 ### Example Build Script
 
 The `CMD` in the Dockerfile invokes a build script that compiles the target and submits outputs:

--- a/docs/crs-development-guide.md
+++ b/docs/crs-development-guide.md
@@ -198,7 +198,7 @@ CMD ["compile_target"]
 > **Offline builds:** `install.sh` needs network access (it downloads `uv` and
 > installs `rsync`). For a fully offline build, replace the two `libCRS` lines
 > with `COPY --from=oss-crs-deps` — see the
-> [oss-crs-deps Image](design/deps-image.md) doc.
+> [Offline install via `oss-crs-deps`](design/libCRS.md) doc.
 
 ### Example Build Script
 

--- a/docs/design/libCRS.md
+++ b/docs/design/libCRS.md
@@ -62,8 +62,8 @@ COPY --from=oss-crs-deps /usr/local/bin/rsync  /usr/local/bin/rsync
 ```
 
 This coexists with `install.sh` — pick `install.sh` for normal networked builds
-and `oss-crs-deps` when the build must be offline. See
-[oss-crs-deps Image](deps-image.md) for details.
+and `oss-crs-deps` when the build must be offline. Note: libCRS is only available
+as a CLI tool, not as a python library.
 
 ## Environment Variables
 

--- a/docs/design/libCRS.md
+++ b/docs/design/libCRS.md
@@ -48,6 +48,23 @@ This installs:
 - `requests >= 2.28.0` (HTTP client for builder sidecar communication)
 - `rsync` (installed automatically by `install.sh`)
 
+### Offline install via `oss-crs-deps`
+
+`install.sh` downloads `uv` and installs `rsync`, so it needs network access at
+build time. For **fully offline builds**, use the `oss-crs-deps` image instead.
+It ships libCRS and rsync as a self-contained Nix closure, built once during
+`oss-crs prepare`, and is pulled into a container with three `COPY` lines:
+
+```dockerfile
+COPY --from=oss-crs-deps /nix/store /nix/store
+COPY --from=oss-crs-deps /usr/local/bin/libCRS /usr/local/bin/libCRS
+COPY --from=oss-crs-deps /usr/local/bin/rsync  /usr/local/bin/rsync
+```
+
+This coexists with `install.sh` — pick `install.sh` for normal networked builds
+and `oss-crs-deps` when the build must be offline. See
+[oss-crs-deps Image](deps-image.md) for details.
+
 ## Environment Variables
 
 libCRS relies on several environment variables injected by CRS Compose at container startup:

--- a/libCRS/.dockerignore
+++ b/libCRS/.dockerignore
@@ -1,2 +1,4 @@
 *.egg-info
+.venv
+tests
 **/__pycache__

--- a/libCRS/README.md
+++ b/libCRS/README.md
@@ -16,6 +16,20 @@ RUN /opt/libCRS/install.sh --cli     # CLI entry point only
 RUN /opt/libCRS/install.sh --python  # importable Python library only
 ```
 
+### Offline install (`oss-crs-deps`)
+
+`install.sh` needs network access (it downloads `uv` and installs `rsync`). For
+fully offline builds, use the `oss-crs-deps` image — a self-contained Nix
+closure of libCRS + rsync built during `oss-crs prepare` — instead:
+
+```dockerfile
+COPY --from=oss-crs-deps /nix/store /nix/store
+COPY --from=oss-crs-deps /usr/local/bin/libCRS /usr/local/bin/libCRS
+COPY --from=oss-crs-deps /usr/local/bin/rsync  /usr/local/bin/rsync
+```
+
+See [oss-crs-deps Image](../docs/design/deps-image.md) for details.
+
 ## Commands
 
 | Category | Commands |
@@ -30,5 +44,6 @@ RUN /opt/libCRS/install.sh --python  # importable Python library only
 ## Documentation
 
 - [Full CLI reference and design](../docs/design/libCRS.md)
+- [oss-crs-deps Image](../docs/design/deps-image.md) - offline libCRS + rsync install via `COPY --from=oss-crs-deps`
 - [CRS Development Guide](../docs/crs-development-guide.md) - how to use libCRS in your CRS
 - [Builder README](../builder/README.md) - builder sidecar API details

--- a/libCRS/README.md
+++ b/libCRS/README.md
@@ -28,7 +28,8 @@ COPY --from=oss-crs-deps /usr/local/bin/libCRS /usr/local/bin/libCRS
 COPY --from=oss-crs-deps /usr/local/bin/rsync  /usr/local/bin/rsync
 ```
 
-See [oss-crs-deps Image](../docs/design/deps-image.md) for details.
+Note: libCRS is only available as a CLI tool, not as a python library.
+See [Offline install via `oss-crs-deps`](../docs/design/libCRS.md) for details.
 
 ## Commands
 
@@ -44,6 +45,5 @@ See [oss-crs-deps Image](../docs/design/deps-image.md) for details.
 ## Documentation
 
 - [Full CLI reference and design](../docs/design/libCRS.md)
-- [oss-crs-deps Image](../docs/design/deps-image.md) - offline libCRS + rsync install via `COPY --from=oss-crs-deps`
 - [CRS Development Guide](../docs/crs-development-guide.md) - how to use libCRS in your CRS
 - [Builder README](../builder/README.md) - builder sidecar API details

--- a/libCRS/deps.Dockerfile
+++ b/libCRS/deps.Dockerfile
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:1
+#
+# Builds the "oss-crs-deps" image (libCRS + rsync) directly via `docker build`.
+#
+# The build stage runs Nix inside a pinned nixos/nix container to produce the
+# `libcrs-runtime` closure (Python with libCRS installed, plus rsync), then
+# assembles a minimal rootfs containing:
+#
+#   /nix/store/<runtime closure>          (only runtime paths, not build deps)
+#   /usr/local/bin/libCRS  -> /nix/store/<hash>-libcrs-runtime/bin/libCRS
+#   /usr/local/bin/rsync   -> /nix/store/<hash>-libcrs-runtime/bin/rsync
+#
+# The final `FROM scratch` stage copies that rootfs, so CRS builder Dockerfiles
+# can do:
+#
+#   COPY --from=oss-crs-deps /nix/store /nix/store
+#   COPY --from=oss-crs-deps /usr/local/bin/libCRS /usr/local/bin/libCRS
+#   COPY --from=oss-crs-deps /usr/local/bin/rsync  /usr/local/bin/rsync
+#
+# The image is never run (no shell/CMD); it exists purely as a COPY --from source.
+ARG NIX_BUILDER_IMAGE=nixos/nix:2.28.3
+FROM ${NIX_BUILDER_IMAGE} AS build
+
+# The libCRS directory (containing flake.nix) is the build context.
+COPY . /build
+
+# Build the runtime closure and stage only its transitive runtime paths into
+# /rootfs. `nix-store -qR` yields the exact runtime closure (equivalent to what
+# dockerTools.buildLayeredImage would ship), excluding build-time dependencies.
+RUN nix build /build#libcrs-runtime -o /out/runtime \
+      --extra-experimental-features 'nix-command flakes' \
+ && mkdir -p /rootfs/nix/store /rootfs/usr/local/bin \
+ && for p in $(nix-store -qR /out/runtime); do cp -a "$p" /rootfs/nix/store/; done \
+ && ln -s "$(readlink -f /out/runtime)/bin/libCRS" /rootfs/usr/local/bin/libCRS \
+ && ln -s "$(readlink -f /out/runtime)/bin/rsync"  /rootfs/usr/local/bin/rsync
+
+FROM scratch
+COPY --from=build /rootfs/ /

--- a/libCRS/flake.lock
+++ b/libCRS/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784120854,
+        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/libCRS/flake.nix
+++ b/libCRS/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "libCRS — Nix-built Docker image providing libCRS + rsync";
+  inputs.nixpkgs.url =
+    "github:NixOS/nixpkgs/nixos-unstable";
+  outputs = { self, nixpkgs }:
+    let
+      forAll = f: nixpkgs.lib.genAttrs [ "x86_64-linux" "aarch64-linux" ]
+        (system: f nixpkgs.legacyPackages.${system});
+    in {
+      packages = forAll (pkgs: rec {
+        libCRS-pkg = pkgs.python3Packages.buildPythonPackage {
+          pname = "libcrs";
+          version = "0.1.0";
+          src = ./.;
+          pyproject = true;
+          build-system = [ pkgs.python3Packages.setuptools ];
+          dependencies = with pkgs.python3Packages; [ watchdog requests ];
+          doCheck = false;
+        };
+
+        # A single Nix closure containing Python (with libCRS installed) and
+        # rsync.  All three are reachable via <closure>/bin/{libCRS,rsync,python3}.
+        libcrs-runtime = pkgs.buildEnv {
+          name = "libcrs-runtime";
+          paths = [
+            (pkgs.python3.withPackages (_: [ libCRS-pkg ]))
+            pkgs.rsync
+          ];
+        };
+
+        # The runtime closure is consumed by libCRS/deps.Dockerfile, which
+        # runs `nix build .#libcrs-runtime` inside a nixos/nix container and
+        # copies the closure into the "oss-crs-deps" image via `docker build`.
+        default = libcrs-runtime;
+      });
+    };
+}

--- a/oss_crs/src/constants.py
+++ b/oss_crs/src/constants.py
@@ -30,6 +30,18 @@ BASE_RUNNER_IMAGE = "gcr.io/oss-fuzz-base/base-runner"
 LEGACY_BASE_OS_VERSION = "legacy"
 DEFAULT_BASE_RUNNER_TAG = "latest"
 
+# Pinned Nix builder image used to build the oss-crs-deps Docker image during
+# prepare. Passed as the NIX_BUILDER_IMAGE build-arg to libCRS/deps.Dockerfile,
+# where Nix runs inside an ephemeral Docker container; the host's own /nix is
+# never touched or required.
+NIX_BUILDER_IMAGE = "nixos/nix@sha256:e623d73af9cac82d1b50784c83e0cf2a4b83bfd2cfe8d5b67809a2fc94e043ac"  # v2.28.3
+
+# The constant Docker image name for the Nix-built libCRS+rsync dependencies
+# image. CRS builder Dockerfiles reference this via COPY --from=oss-crs-deps.
+# Built during prepare via `docker build` (see oss_crs/src/libcrs_nix.py and
+# libCRS/deps.Dockerfile) and tagged oss-crs-deps:latest.
+OSS_CRS_DEPS_IMAGE = "oss-crs-deps"
+
 # base_os_version values that map to a known base-runner OS tag. Unknown values
 # are still passed through as the runner tag verbatim (OSS-Fuzz may add new OS
 # lines over time), but warned about since a non-existent tag fails at pull.

--- a/oss_crs/src/crs_compose.py
+++ b/oss_crs/src/crs_compose.py
@@ -37,6 +37,7 @@ from .cgroup import (
     create_run_cgroups,
     cleanup_cgroup,
 )
+from .libcrs_nix import build_deps_image
 
 import docker
 import docker.errors
@@ -583,7 +584,21 @@ class CRSCompose:
     def __prepare_oss_crs_infra(
         self, publish: bool = False, docker_registry: Optional[str] = None
     ) -> "TaskResult":
-        # TODO
+        """Build the oss-crs-deps Docker image (libCRS + rsync via Nix).
+
+        This is a framework-level prepare step that runs once during prepare.
+        The image is built with ``docker build`` (Nix runs inside the build
+        stage) and tagged ``oss-crs-deps:latest``. CRS builder Dockerfiles can
+        then use ``COPY --from=oss-crs-deps`` to get libCRS and rsync without
+        any network access at build time.
+        """
+        libcrs_dir = renderer.LIBCRS_PATH
+        success, detail = build_deps_image(libcrs_dir)
+        if not success:
+            return TaskResult(
+                success=False,
+                error=f"Failed to build oss-crs-deps image: {detail}",
+            )
         return TaskResult(success=True)
 
     def prepare(self, publish: bool = False, no_pull: bool = False) -> bool:

--- a/oss_crs/src/libcrs_nix.py
+++ b/oss_crs/src/libcrs_nix.py
@@ -1,0 +1,113 @@
+"""Build the oss-crs-deps Docker image (libCRS + rsync via Nix).
+
+During ``prepare``, the framework builds ``libCRS/deps.Dockerfile`` with
+``docker build``.  Its build stage runs Nix inside a pinned ``nixos/nix``
+container to produce the ``libcrs-runtime`` closure, then assembles a
+minimal ``FROM scratch`` image tagged ``oss-crs-deps:latest``.
+
+The image contains the full ``libcrs-runtime`` Nix closure (so that
+``/nix/store`` is populated), together with two baked symlinks::
+
+    /usr/local/bin/libCRS  ->  /nix/store/<hash>-libcrs-runtime/bin/libCRS
+    /usr/local/bin/rsync   ->  /nix/store/<hash>-libcrs-runtime/bin/rsync
+
+CRS builder Dockerfiles can then do::
+
+    COPY --from=oss-crs-deps /nix/store /nix/store
+    COPY --from=oss-crs-deps /usr/local/bin/libCRS /usr/local/bin/libCRS
+    COPY --from=oss-crs-deps /usr/local/bin/rsync  /usr/local/bin/rsync
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from .constants import NIX_BUILDER_IMAGE, OSS_CRS_DEPS_IMAGE
+
+# Dockerfile (relative to the libCRS directory) that builds the deps image.
+DEPS_DOCKERFILE_NAME = "deps.Dockerfile"
+
+
+def docker_available() -> bool:
+    """Return True when the ``docker`` CLI is on PATH."""
+    return shutil.which("docker") is not None
+
+
+def deps_image_exists() -> bool:
+    """Return True when the oss-crs-deps image is already loaded."""
+    if not docker_available():
+        return False
+    result = subprocess.run(
+        ["docker", "image", "inspect", OSS_CRS_DEPS_IMAGE],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def build_deps_image(libcrs_dir: Path) -> tuple[bool, str]:
+    """Build the ``oss-crs-deps`` Docker image via ``docker build``.
+
+    Builds ``deps.Dockerfile`` with the ``libCRS`` directory as the build
+    context.  The Dockerfile's build stage runs ``nix build`` inside a
+    pinned ``nixos/nix`` container (passed as the ``NIX_BUILDER_IMAGE``
+    build-arg) and copies the resulting runtime closure into a
+    ``FROM scratch`` image tagged ``oss-crs-deps:latest``.
+
+    If the image already exists (e.g. from a previous ``prepare``), the
+    build is skipped.
+
+    Returns:
+        A ``(success, detail)`` tuple.  ``success`` is True on success.
+        On failure, ``detail`` contains a human-readable explanation
+        (including captured subprocess output) for debugging.  On success
+        ``detail`` is an empty string.
+    """
+    if not docker_available():
+        return False, (
+            "docker CLI not found on PATH; the oss-crs-deps image is built "
+            f"with 'docker build' using the {NIX_BUILDER_IMAGE} container"
+        )
+
+    if deps_image_exists():
+        return True, ""
+
+    flake_nix = libcrs_dir / "flake.nix"
+    if not flake_nix.exists():
+        return False, f"flake.nix not found in libCRS directory: {flake_nix}"
+
+    dockerfile = libcrs_dir / DEPS_DOCKERFILE_NAME
+    if not dockerfile.exists():
+        return (
+            False,
+            f"{DEPS_DOCKERFILE_NAME} not found in libCRS directory: {dockerfile}",
+        )
+
+    docker_cmd = [
+        "docker",
+        "build",
+        "-t",
+        f"{OSS_CRS_DEPS_IMAGE}:latest",
+        "-f",
+        str(dockerfile),
+        "--build-arg",
+        f"NIX_BUILDER_IMAGE={NIX_BUILDER_IMAGE}",
+        str(libcrs_dir.resolve()),
+    ]
+
+    result = subprocess.run(
+        docker_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if result.returncode != 0:
+        return False, (
+            f"'docker build' failed (exit {result.returncode}) while building "
+            f"the oss-crs-deps image in {NIX_BUILDER_IMAGE}.\n"
+            f"Command: {' '.join(docker_cmd)}\n"
+            f"Output:\n{result.stdout}"
+        )
+
+    return True, ""

--- a/oss_crs/tests/unit/test_libcrs_nix.py
+++ b/oss_crs/tests/unit/test_libcrs_nix.py
@@ -1,0 +1,119 @@
+"""Unit tests for oss_crs.src.libcrs_nix module."""
+
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+
+from oss_crs.src.libcrs_nix import (
+    docker_available,
+    deps_image_exists,
+    build_deps_image,
+)
+from oss_crs.src.constants import OSS_CRS_DEPS_IMAGE
+
+
+class TestDockerAvailable:
+    """Tests for docker_available."""
+
+    @patch("oss_crs.src.libcrs_nix.shutil.which")
+    def test_returns_true_when_docker_on_path(self, mock_which):
+        mock_which.return_value = "/usr/bin/docker"
+        assert docker_available() is True
+
+    @patch("oss_crs.src.libcrs_nix.shutil.which")
+    def test_returns_false_when_docker_not_found(self, mock_which):
+        mock_which.return_value = None
+        assert docker_available() is False
+
+
+class TestDepsImageExists:
+    """Tests for deps_image_exists."""
+
+    @patch("oss_crs.src.libcrs_nix.subprocess.run")
+    @patch("oss_crs.src.libcrs_nix.docker_available", return_value=True)
+    def test_returns_true_when_image_inspect_succeeds(self, mock_avail, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        assert deps_image_exists() is True
+
+    @patch("oss_crs.src.libcrs_nix.subprocess.run")
+    @patch("oss_crs.src.libcrs_nix.docker_available", return_value=True)
+    def test_returns_false_when_image_inspect_fails(self, mock_avail, mock_run):
+        mock_run.return_value = MagicMock(returncode=1)
+        assert deps_image_exists() is False
+
+    @patch("oss_crs.src.libcrs_nix.docker_available", return_value=False)
+    def test_returns_false_when_docker_not_available(self, mock_avail):
+        assert deps_image_exists() is False
+
+
+class TestBuildDepsImage:
+    """Tests for build_deps_image."""
+
+    @patch("oss_crs.src.libcrs_nix.docker_available", return_value=False)
+    def test_returns_false_when_docker_not_available(self, mock_avail):
+        success, detail = build_deps_image(Path("/fake/libcrs"))
+        assert success is False
+        assert "docker" in detail.lower()
+
+    @patch("oss_crs.src.libcrs_nix.deps_image_exists", return_value=True)
+    @patch("oss_crs.src.libcrs_nix.docker_available", return_value=True)
+    def test_skips_build_when_image_already_exists(self, mock_avail, mock_exists):
+        success, detail = build_deps_image(Path("/fake/libcrs"))
+        assert success is True
+        assert detail == ""
+
+    @patch("oss_crs.src.libcrs_nix.docker_available", return_value=True)
+    @patch("oss_crs.src.libcrs_nix.deps_image_exists", return_value=False)
+    def test_returns_false_when_flake_nix_not_found(self, mock_exists, mock_avail):
+        success, detail = build_deps_image(Path("/fake/nonexistent"))
+        assert success is False
+        assert "flake.nix" in detail
+
+    @patch("oss_crs.src.libcrs_nix.docker_available", return_value=True)
+    @patch("oss_crs.src.libcrs_nix.deps_image_exists", return_value=False)
+    def test_returns_false_when_dockerfile_not_found(
+        self, mock_exists, mock_avail, tmp_path
+    ):
+        # flake.nix present but deps.Dockerfile missing
+        (tmp_path / "flake.nix").write_text("{}")
+        success, detail = build_deps_image(tmp_path)
+        assert success is False
+        assert "deps.Dockerfile" in detail
+
+    @patch("oss_crs.src.libcrs_nix.subprocess.run")
+    @patch("oss_crs.src.libcrs_nix.deps_image_exists", return_value=False)
+    @patch("oss_crs.src.libcrs_nix.docker_available", return_value=True)
+    def test_docker_build_success(self, mock_avail, mock_exists, mock_run, tmp_path):
+        """A successful `docker build` returns (True, "")."""
+        (tmp_path / "flake.nix").write_text("{}")
+        (tmp_path / "deps.Dockerfile").write_text("FROM scratch\n")
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        success, detail = build_deps_image(tmp_path)
+
+        assert (success, detail) == (True, "")
+        # Verify the issued command is a `docker build` tagging oss-crs-deps
+        # and passing the NIX_BUILDER_IMAGE build-arg.
+        cmd = mock_run.call_args[0][0]
+        assert cmd[:2] == ["docker", "build"]
+        assert "-t" in cmd
+        assert f"{OSS_CRS_DEPS_IMAGE}:latest" in cmd
+        assert any(a.startswith("NIX_BUILDER_IMAGE=") for a in cmd)
+
+    @patch("oss_crs.src.libcrs_nix.subprocess.run")
+    @patch("oss_crs.src.libcrs_nix.deps_image_exists", return_value=False)
+    @patch("oss_crs.src.libcrs_nix.docker_available", return_value=True)
+    def test_returns_false_when_docker_build_fails(
+        self, mock_avail, mock_exists, mock_run, tmp_path
+    ):
+        (tmp_path / "flake.nix").write_text("{}")
+        (tmp_path / "deps.Dockerfile").write_text("FROM scratch\n")
+
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="docker build error", stderr=""
+        )
+
+        success, detail = build_deps_image(tmp_path)
+
+        assert success is False
+        assert "docker build error" in detail


### PR DESCRIPTION
## Summary

Describe what changed and why.

libCRS is now built during the prepare step using a Nix derivation and is stored as a docker image. During the build-target/run steps, the Nix store is copied into /nix/store which is then usable by the install script/run time images. Only the libCRS CLI tool is supported, not the python library.

## User Impact

- [ ] User-facing change
- [x] Internal-only change

If user-facing, describe CLI/API/config/docs impact and migration steps.

## Release Note / Changelog

- [ ] I updated `CHANGELOG.md` (`[Unreleased]`) for user-facing changes
- [X] No changelog entry needed (internal-only refactor/test/chore)

If this PR includes deprecation or breaking behavior, include:
- replacement path for users
- planned removal version/release window

## Validation

List tests/checks run and their results.

Successfully passes all unit tests.

## Checklist

- [x] I followed Conventional Commits
- [X] I updated docs for behavior/config/CLI changes
- [X] I added/updated tests for behavior changes
- [X] I considered backward compatibility and migration impact
