### PR TITLE
Add export and import subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ stricter subset of Keep a Changelog).
 
 ### Changed
 
+- `oss-crs export` and `oss-crs import` commands — imports/exports docker images/CRS source code to transfer to another host.
 - Run-phase modules now default to `target_dependent: true`, so their images are built once per target during `build-target`. Set `target_dependent: false` for modules that can be built once during `prepare`.
 - `--offline` flag for all subcommands: disables git fetch
 - `oss-crs build-target` now validates `--bug-candidate`/`--bug-candidate-dir` the same way `oss-crs run` does: a missing path, or a directory passed to `--bug-candidate` (or a file passed to `--bug-candidate-dir`), fails before any container starts instead of being silently ignored.

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,9 +40,11 @@ For a quick introduction and setup instructions, see the [project README](../REA
 Every CRS campaign follows three phases managed by `oss-crs`:
 
 1. **Prepare** — Pull CRS source repositories and build Docker images (`oss-crs prepare`)
-2. **Build Target** — Compile the target project and run each CRS's target build pipeline (`oss-crs build-target`). Pass `--incremental-build` to create Docker snapshots for faster rebuilds. Pass `--coverage` to additionally build a coverage-instrumented binary for the [Web Dashboard](#web-dashboard).
-3. **Run** — Launch all CRSs and shared infrastructure via Docker Compose (`oss-crs run`). Pass `--incremental-build` to use snapshot images for ephemeral rebuild containers. Pass `--web-ui` to monitor the run live in the [Web Dashboard](#web-dashboard). Pass `--forward-artifacts <run-id>[,<run-id>...]` to seed a run with artifacts from previous runs, or pass bare `--forward-artifacts` in an interactive terminal to choose from prior artifact-producing runs for the same target project.
-4. **Clean** — Remove Docker images and workdir artifacts from previous phases (`oss-crs clean`). Target a specific phase with `clean prepare`, `clean build-target`, or `clean run`, or clean everything at once. Add `--artifacts` to also remove workdir build/run directories.
+2. **Export (optional)** — Bundle prepared Docker images and CRS source for transfer to another host (`oss-crs export`). Specify the CRS with --compose-file.
+3. **Import (on another host)** — Load the exported Docker images and restore CRS source (`oss-crs import --in prepared.tar`).
+4. **Build Target** — Compile the target project and run each CRS's target build pipeline (`oss-crs build-target`). Pass `--incremental-build` to create Docker snapshots for faster rebuilds. Pass `--coverage` to additionally build a coverage-instrumented binary for the [Web Dashboard](#web-dashboard).
+5. **Run** — Launch all CRSs and shared infrastructure via Docker Compose (`oss-crs run`). Pass `--incremental-build` to use snapshot images for ephemeral rebuild containers. Pass `--web-ui` to monitor the run live in the [Web Dashboard](#web-dashboard). Pass `--forward-artifacts <run-id>[,<run-id>...]` to seed a run with artifacts from previous runs, or pass bare `--forward-artifacts` in an interactive terminal to choose from prior artifact-producing runs for the same target project.
+6. **Clean** — Remove Docker images and workdir artifacts from previous phases (`oss-crs clean`). Target a specific phase with `clean prepare`, `clean build-target`, or `clean run`, or clean everything at once. Add `--artifacts` to also remove workdir build/run directories.
 
 ### CRS Isolation
 

--- a/oss_crs/src/cli/clean.py
+++ b/oss_crs/src/cli/clean.py
@@ -8,15 +8,22 @@ from pathlib import Path
 import docker
 import docker.errors
 
-from ..constants import PRESERVED_BUILDER_REPO, PRESERVED_RUNNER_REPO
+from ..constants import (
+    OSS_CRS_ALPINE_TAG,
+)
 from ..utils import (
     confirm,
     get_console,
     green,
-    log_warning,
     red,
     yellow,
     rm_with_docker,
+)
+from .discovery import (
+    discover_artifact_dirs,
+    discover_build_target_images,
+    discover_prepare_images,
+    discover_run_images,
 )
 
 
@@ -52,162 +59,6 @@ class CleanPlan:
 
 
 # ---------------------------------------------------------------------------
-# Discovery helpers
-# ---------------------------------------------------------------------------
-
-
-def discover_prepare_images(crs_compose) -> list[str]:
-    """Discover images produced by prepare-phase bake for all CRSs."""
-    candidate_tags: list[str] = []
-    for crs in crs_compose.crs_list:
-        try:
-            candidate_tags.extend(crs.get_bake_image_tags())
-        except Exception as exc:
-            log_warning(f"Could not discover prepare images for {crs.name}: {exc}")
-
-    # Only include images that actually exist locally
-    client = docker.from_env()
-    existing: list[str] = []
-    for tag in _dedupe(candidate_tags):
-        try:
-            client.images.get(tag)
-            existing.append(tag)
-        except docker.errors.ImageNotFound:
-            pass
-    return existing
-
-
-def discover_build_target_images(
-    crs_compose, target=None
-) -> tuple[list[str], list[str], list[str]]:
-    """Discover builder, snapshot, and target-base images scoped to this compose config.
-
-    Uses CRS names from the compose config and build-ids from the workdir to
-    match only images belonging to this configuration.
-
-    Returns (builder_tags, snapshot_tags, target_tags).
-    """
-    client = docker.from_env()
-    builder_tags: list[str] = []
-    snapshot_tags: list[str] = []
-    target_tags: list[str] = []
-
-    crs_names = {crs.name for crs in crs_compose.crs_list}
-    build_ids = {b.build_id for b in crs_compose.work_dir.iter_builds()}
-
-    # Preserved builders: oss-crs-builder:{crs_name}-{build_name}-{build_id}
-    # Filter by matching crs_name prefix AND build_id suffix
-    for img in client.images.list(name=PRESERVED_BUILDER_REPO):
-        for tag in img.tags:
-            _, _, tag_suffix = tag.partition(":")
-            if not tag_suffix:
-                continue
-            # tag_suffix is "{crs_name}-{build_name}-{build_id}"
-            # Check if it starts with any known CRS name and ends with a known build_id
-            for crs_name in crs_names:
-                prefix = f"{crs_name}-"
-                if tag_suffix.startswith(prefix):
-                    remainder = tag_suffix[len(prefix) :]
-                    # remainder is "{build_name}-{build_id}"
-                    for bid in build_ids:
-                        if remainder.endswith(f"-{bid}"):
-                            builder_tags.append(tag)
-                            break
-                    break
-
-    # Snapshots: oss-crs-snapshot:{kind}-{crs_name}-{build_name}-{build_id}
-    # Same scoping logic
-    for img in client.images.list(name="oss-crs-snapshot"):
-        for tag in img.tags:
-            _, _, tag_suffix = tag.partition(":")
-            if not tag_suffix:
-                continue
-            for crs_name in crs_names:
-                if f"-{crs_name}-" in tag_suffix:
-                    for bid in build_ids:
-                        if tag_suffix.endswith(f"-{bid}"):
-                            snapshot_tags.append(tag)
-                            break
-                    break
-            # Also match content-hash snapshots if they're under our build dirs
-            # These use format "content-{hash}" and aren't CRS-scoped, but we
-            # include them since they were created by builds in this workdir
-            if tag_suffix.startswith("test-"):
-                for bid in build_ids:
-                    if tag_suffix == f"test-{bid}":
-                        snapshot_tags.append(tag)
-                        break
-
-    # Target base images (only if target provided)
-    if target is not None:
-        tag = target.get_docker_image_name()
-        try:
-            client.images.get(tag)
-            target_tags.append(tag)
-        except docker.errors.ImageNotFound:
-            pass
-
-    # Preserved runner images: oss-crs-runner:{crs_name}-{module}-{repo_hash}
-    # Produced by build-target for target-dependent run modules. Scope by CRS
-    # name (and by target repo hash when a target is provided).
-    repo_hash = target.get_docker_image_name().rsplit(":", 1)[-1] if target else None
-    for img in client.images.list(name=PRESERVED_RUNNER_REPO):
-        for tag in img.tags:
-            if not tag.startswith(f"{PRESERVED_RUNNER_REPO}:"):
-                continue
-            _, _, tag_suffix = tag.partition(":")
-            if not tag_suffix:
-                continue
-            for crs_name in crs_names:
-                if tag_suffix.startswith(f"{crs_name}-"):
-                    if repo_hash is None or tag_suffix.endswith(f"-{repo_hash}"):
-                        builder_tags.append(tag)
-                    break
-
-    return (
-        _dedupe(builder_tags),
-        _dedupe(snapshot_tags),
-        _dedupe(target_tags),
-    )
-
-
-def discover_run_images(crs_compose) -> list[str]:
-    """Discover run-phase images scoped to this compose config.
-
-    Enumerates run-ids from the workdir and matches compose project images
-    with the pattern ``crs_compose_{run_id}*``.
-    """
-    run_ids = {r.run_id for r in crs_compose.work_dir.iter_runs()}
-    if not run_ids:
-        return []
-
-    client = docker.from_env()
-    tags: list[str] = []
-    for img in client.images.list():
-        for tag in img.tags:
-            for rid in run_ids:
-                if tag.startswith(f"crs_compose_{rid}"):
-                    tags.append(tag)
-                    break
-    return _dedupe(tags)
-
-
-def discover_artifact_dirs(work_dir, phase: str) -> list[Path]:
-    """Find builds/ and/or runs/ directories under each sanitizer dir.
-
-    Args:
-        work_dir: A WorkDir instance.
-        phase: One of "prepare", "build-target", "run", or "all".
-    """
-    dirs: list[Path] = []
-    if phase in ("build-target", "all"):
-        dirs.extend(b.path for b in work_dir.iter_builds())
-    if phase in ("run", "all"):
-        dirs.extend(r.path for r in work_dir.iter_runs())
-    return dirs
-
-
-# ---------------------------------------------------------------------------
 # Display
 # ---------------------------------------------------------------------------
 
@@ -230,7 +81,7 @@ def _dir_size(path: Path) -> str:
                 "--rm",
                 "-v",
                 f"{path}:/data:ro",
-                "alpine",
+                OSS_CRS_ALPINE_TAG,
                 "du",
                 "-sb",
                 "/data",
@@ -503,13 +354,3 @@ def add_clean_command(
     _add_clean_flags(run_p)
     add_common_arguments_fn(run_p)
     _add_optional_target_args(run_p)
-
-
-def _dedupe(lst: list[str]) -> list[str]:
-    seen: set[str] = set()
-    out: list[str] = []
-    for item in lst:
-        if item not in seen:
-            seen.add(item)
-            out.append(item)
-    return out

--- a/oss_crs/src/cli/crs_compose.py
+++ b/oss_crs/src/cli/crs_compose.py
@@ -16,6 +16,8 @@ from .artifacts import handle_artifacts
 from .archive import handle_archive
 from .clean import add_clean_command, handle_clean
 from .setup import add_setup_command, handle_setup
+from .export import handle_export
+from .import_cmd import handle_import
 
 
 DEFAULT_WORK_DIR = (Path(__file__) / "../../../../.oss-crs-workdir").resolve()
@@ -533,6 +535,40 @@ def handle_web_ui(args) -> bool:
     return False
 
 
+def add_export_command(subparsers):
+    export = subparsers.add_parser(
+        "export",
+        help="Bundle prepared images and CRS source into a tarball",
+    )
+    add_common_arguments(export)
+    export.add_argument(
+        "--out",
+        type=str,
+        required=True,
+        help="Output path for the bundle (e.g. prepared.tar).",
+    )
+
+
+def add_import_command(subparsers):
+    import_parser = subparsers.add_parser(
+        "import",
+        help="Restore prepared images and CRS source from a bundle",
+    )
+    import_parser.add_argument(
+        "--in",
+        dest="in_path",
+        type=str,
+        required=True,
+        help="Path to the bundle produced by 'export' (e.g. prepared.tar).",
+    )
+    import_parser.add_argument(
+        "--work-dir",
+        type=Path,
+        default=DEFAULT_WORK_DIR,
+        help="Working directory for CRS Compose operations",
+    )
+
+
 def add_gen_compose_command(subparsers):
     gen_compose = subparsers.add_parser(
         "gen-compose",
@@ -802,6 +838,8 @@ def cli() -> bool | int:
     add_artifacts_command(subparsers)
     add_archive_command(subparsers)
     add_check_command(subparsers)
+    add_export_command(subparsers)
+    add_import_command(subparsers)
     add_gen_compose_command(subparsers)
     add_clean_command(subparsers, add_common_arguments, add_target_arguments)
     add_setup_command(subparsers)
@@ -842,6 +880,11 @@ def cli() -> bool | int:
     # Handle clean early - it manages its own CRSCompose initialization
     if args.command == "clean":
         return handle_clean(args)
+
+    # Handle import early - it must NOT clone CRS repos (the bundle carries the
+    # source), so it derives the work-dir itself instead of building a CRSCompose.
+    if args.command == "import":
+        return handle_import(args)
 
     # Skip CRS repo init for commands that don't need it
     skip_crs_init = args.command in ("artifacts", "archive")
@@ -929,6 +972,8 @@ def cli() -> bool | int:
     elif args.command == "archive":
         target = init_target_from_args(args)
         return handle_archive(args, crs_compose, target)
+    elif args.command == "export":
+        return handle_export(args, crs_compose)
     elif args.command == "check":
         pass
     return True

--- a/oss_crs/src/cli/discovery.py
+++ b/oss_crs/src/cli/discovery.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: MIT
+"""Image discovery helpers for clean and export commands."""
+
+import docker
+import docker.errors
+from pathlib import Path
+
+from ..constants import (
+    OSS_CRS_ALPINE_TAG,
+    OSS_CRS_DEPS_IMAGE,
+    OSS_CRS_INFRA_SIDECAR_IMAGES,
+    OSS_CRS_INTERNAL_LLM_IMAGES,
+    OSS_CRS_INTERNAL_LLM_SIDECAR_IMAGES,
+    PRESERVED_BUILDER_REPO,
+    PRESERVED_RUNNER_REPO,
+)
+from ..crs_compose import _lifecycle_needed
+from ..utils import log_warning, preserved_runner_image_name
+
+
+def _dedupe(lst: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in lst:
+        if item not in seen:
+            seen.add(item)
+            out.append(item)
+    return out
+
+
+def discover_infra_images(crs_compose) -> list[str]:
+    """Return framework-level image tags produced during prepare.
+
+    Mirrors ``CRSCompose.__prepare_oss_crs_infra``: always includes
+    oss-crs-deps, alpine, and the shared infra sidecars (minus lifecycle
+    when it will never be started); adds internal-LLM images when the LLM
+    stack is in internal mode.
+    """
+    tags = [
+        f"{OSS_CRS_DEPS_IMAGE}:latest",
+        OSS_CRS_ALPINE_TAG,
+    ]
+
+    sidecars = dict(OSS_CRS_INFRA_SIDECAR_IMAGES)
+    if not _lifecycle_needed(crs_compose.crs_list):
+        sidecars.pop("lifecycle", None)
+    tags.extend(sidecars.values())
+
+    if crs_compose.llm.exists() and crs_compose.llm.mode == "internal":
+        tags.extend(OSS_CRS_INTERNAL_LLM_SIDECAR_IMAGES.values())
+        tags.extend(OSS_CRS_INTERNAL_LLM_IMAGES.values())
+
+    return _dedupe(tags)
+
+
+def discover_prepare_images(crs_compose) -> list[str]:
+    """Discover framework and CRS images produced during prepare."""
+    candidate_tags = discover_infra_images(crs_compose)
+    for crs in crs_compose.crs_list:
+        try:
+            candidate_tags.extend(crs.get_bake_image_tags())
+        except Exception as exc:
+            log_warning(f"Could not discover prepare images for {crs.name}: {exc}")
+
+        # Target-independent run-phase images are built during prepare.
+        crs_run_phase = getattr(crs.config, "crs_run_phase", None)
+        if crs_run_phase is not None:
+            for module_name, module_config in crs_run_phase.modules.items():
+                if not module_config.target_dependent:
+                    candidate_tags.append(
+                        preserved_runner_image_name(crs.name, module_name)
+                    )
+
+    # Only include images that actually exist locally
+    client = docker.from_env()
+    existing: list[str] = []
+    for tag in _dedupe(candidate_tags):
+        try:
+            client.images.get(tag)
+            existing.append(tag)
+        except docker.errors.ImageNotFound:
+            pass
+    return existing
+
+
+def discover_build_target_images(
+    crs_compose, target=None
+) -> tuple[list[str], list[str], list[str]]:
+    """Discover builder, snapshot, and target-base images scoped to this compose config.
+
+    Uses CRS names from the compose config and build-ids from the workdir to
+    match only images belonging to this configuration.
+
+    Returns (builder_tags, snapshot_tags, target_tags).
+    """
+    client = docker.from_env()
+    builder_tags: list[str] = []
+    snapshot_tags: list[str] = []
+    target_tags: list[str] = []
+
+    crs_names = {crs.name for crs in crs_compose.crs_list}
+    build_ids = {b.build_id for b in crs_compose.work_dir.iter_builds()}
+
+    # Preserved builders: oss-crs-builder:{crs_name}-{build_name}-{build_id}
+    # Filter by matching crs_name prefix AND build_id suffix
+    for img in client.images.list(name=PRESERVED_BUILDER_REPO):
+        for tag in img.tags:
+            _, _, tag_suffix = tag.partition(":")
+            if not tag_suffix:
+                continue
+            # tag_suffix is "{crs_name}-{build_name}-{build_id}"
+            # Check if it starts with any known CRS name and ends with a known build_id
+            for crs_name in crs_names:
+                prefix = f"{crs_name}-"
+                if tag_suffix.startswith(prefix):
+                    remainder = tag_suffix[len(prefix) :]
+                    # remainder is "{build_name}-{build_id}"
+                    for bid in build_ids:
+                        if remainder.endswith(f"-{bid}"):
+                            builder_tags.append(tag)
+                            break
+                    break
+
+    # Snapshots: oss-crs-snapshot:{kind}-{crs_name}-{build_name}-{build_id}
+    # Same scoping logic
+    for img in client.images.list(name="oss-crs-snapshot"):
+        for tag in img.tags:
+            _, _, tag_suffix = tag.partition(":")
+            if not tag_suffix:
+                continue
+            for crs_name in crs_names:
+                if f"-{crs_name}-" in tag_suffix:
+                    for bid in build_ids:
+                        if tag_suffix.endswith(f"-{bid}"):
+                            snapshot_tags.append(tag)
+                            break
+                    break
+            # Also match content-hash snapshots if they're under our build dirs
+            # These use format "content-{hash}" and aren't CRS-scoped, but we
+            # include them since they were created by builds in this workdir
+            if tag_suffix.startswith("test-"):
+                for bid in build_ids:
+                    if tag_suffix == f"test-{bid}":
+                        snapshot_tags.append(tag)
+                        break
+
+    # Target base images (only if target provided)
+    if target is not None:
+        tag = target.get_docker_image_name()
+        try:
+            client.images.get(tag)
+            target_tags.append(tag)
+        except docker.errors.ImageNotFound:
+            pass
+
+    # Preserved runner images: oss-crs-runner:{crs_name}-{module}-{repo_hash}
+    # Produced by build-target for target-dependent run modules. Scope by CRS
+    # name (and by target repo hash when a target is provided).
+    if target is not None:
+        repo_hash = target.get_docker_image_name().rsplit(":", 1)[-1]
+    else:
+        repo_hash = None
+    for img in client.images.list(name=PRESERVED_RUNNER_REPO):
+        for tag in img.tags:
+            if not tag.startswith(f"{PRESERVED_RUNNER_REPO}:"):
+                continue
+            _, _, tag_suffix = tag.partition(":")
+            if not tag_suffix:
+                continue
+            for crs_name in crs_names:
+                if tag_suffix.startswith(f"{crs_name}-"):
+                    if repo_hash is None or tag_suffix.endswith(f"-{repo_hash}"):
+                        builder_tags.append(tag)
+                    break
+
+    return (
+        _dedupe(builder_tags),
+        _dedupe(snapshot_tags),
+        _dedupe(target_tags),
+    )
+
+
+def discover_run_images(crs_compose) -> list[str]:
+    """Discover run-phase images scoped to this compose config.
+
+    Enumerates run-ids from the workdir and matches compose project images
+    with the pattern ``crs_compose_{run_id}*``.
+    """
+    run_ids = {r.run_id for r in crs_compose.work_dir.iter_runs()}
+    if not run_ids:
+        return []
+
+    client = docker.from_env()
+    tags: list[str] = []
+    for img in client.images.list():
+        for tag in img.tags:
+            for rid in run_ids:
+                if tag.startswith(f"crs_compose_{rid}"):
+                    tags.append(tag)
+                    break
+    return _dedupe(tags)
+
+
+def discover_artifact_dirs(work_dir, phase: str) -> list[Path]:
+    """Find builds/ and/or runs/ directories under each sanitizer dir.
+
+    Args:
+        work_dir: A WorkDir instance.
+        phase: One of "prepare", "build-target", "run", or "all".
+    """
+    dirs: list[Path] = []
+    if phase in ("build-target", "all"):
+        dirs.extend(b.path for b in work_dir.iter_builds())
+    if phase in ("run", "all"):
+        dirs.extend(r.path for r in work_dir.iter_runs())
+    return dirs

--- a/oss_crs/src/cli/export.py
+++ b/oss_crs/src/cli/export.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: MIT
+"""Export prepared Docker images and CRS source trees into a tarball.
+
+The bundle contains an export manifest, an optional ``images.tar.zst``
+produced by streaming ``docker save`` through ``zstd``, and each
+configured CRS source tree under ``crs_src/``.  Docker images are
+optional because a CRS may not produce any prepare-phase images.
+"""
+
+import json
+import platform
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+from .discovery import discover_prepare_images
+
+
+def _stream_images(image_tags: list[str], dest: Path) -> bool:
+    """Stream ``docker save`` through ``zstd`` into *dest*.
+
+    The zstd compression eliminates the need for an uncompressed
+    temporary ``images.tar`` file, reducing peak disk usage by roughly
+    half.
+    """
+    print(f"Saving {len(image_tags)} image(s) with 'docker save | zstd'...")
+    save = subprocess.Popen(
+        ["docker", "save", *image_tags],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if save.stdout is None:
+        print("Error: 'docker save' produced no output pipe.", file=sys.stderr)
+        return False
+    zstd = subprocess.Popen(
+        ["zstd", "-T0", "-10", "-o", str(dest), "-q"],
+        stdin=save.stdout,
+        stderr=subprocess.PIPE,
+    )
+    save.stdout.close()
+
+    # Wait for both processes. If one fails the other may receive SIGPIPE
+    # or EOF, so we collect all available error information before deciding
+    # what went wrong.
+    save_rc = save.wait()
+    zstd_rc = zstd.wait()
+
+    save_error = (
+        save.stderr.read().decode(errors="replace").strip() if save.stderr else ""
+    )
+    zstd_error = (
+        zstd.stderr.read().decode(errors="replace").strip() if zstd.stderr else ""
+    )
+
+    # Collect all failures — the root cause might be in either process.
+    errors: list[str] = []
+
+    if save_rc != 0 and save_error:
+        errors.append(save_error)
+
+    if zstd_rc != 0 and zstd_error:
+        errors.append(zstd_error)
+
+    if errors:
+        print("Error: image export failed.\n", file=sys.stderr)
+        for err in errors:
+            print(err, file=sys.stderr)
+            print(file=sys.stderr)
+        return False
+
+    return True
+
+
+def handle_export(args, crs_compose) -> bool:
+    """Export locally prepared images and CRS sources."""
+    out_path = Path(args.out)
+    image_tags = discover_prepare_images(crs_compose)
+    if not image_tags:
+        print(
+            "Warning: no prepared images found locally "
+            "(the CRS may have no prepare phase, or 'prepare' was not run); "
+            "exporting CRS source only."
+        )
+
+    crs_sources: list[tuple[str, Path]] = []
+    for crs in crs_compose.crs_list:
+        src = Path(crs.crs_path)
+        if src.exists():
+            crs_sources.append((crs.name, src))
+        else:
+            print(f"No source found for CRS '{crs.name}' at {src}; skipping.")
+
+    if not image_tags and not crs_sources:
+        print(
+            "Error: nothing to export (no prepared images or CRS source found).",
+            file=sys.stderr,
+        )
+        return False
+
+    manifest = {
+        "oss_crs_export_version": 1,
+        "platform": platform.machine(),
+        "images": image_tags,
+        "crs_sources": [name for name, _ in crs_sources],
+        "compression": "zstd",
+    }
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as staging_str:
+        staging = Path(staging_str)
+
+        images_tar_zst: Path | None = None
+        if image_tags:
+            images_tar_zst = staging / "images.tar.zst"
+            if not _stream_images(image_tags, images_tar_zst):
+                return False
+
+        manifest_json = staging / "export-manifest.json"
+        manifest_json.write_text(json.dumps(manifest, indent=2))
+
+        print(f"Writing bundle to {out_path}...")
+        with tarfile.open(out_path, "w", format=tarfile.GNU_FORMAT) as tar:
+            tar.add(manifest_json, arcname="export-manifest.json")
+            if images_tar_zst is not None:
+                tar.add(images_tar_zst, arcname="images.tar.zst")
+            for name, src in crs_sources:
+                tar.add(src, arcname=f"crs_src/{name}")
+
+    summary = []
+    if image_tags:
+        summary.append(f"{len(image_tags)} image(s)")
+    if crs_sources:
+        summary.append(f"{len(crs_sources)} CRS source(s)")
+    print(f"Exported {' + '.join(summary)} to {out_path}")
+    return True

--- a/oss_crs/src/cli/import_cmd.py
+++ b/oss_crs/src/cli/import_cmd.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: MIT
+"""Import Docker images and CRS source from an ``oss-crs export`` bundle."""
+
+import json
+import platform
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+from ..utils import rm_with_docker
+
+
+def _load_images(staging: Path) -> bool:
+    """Load bundled images into the local Docker daemon.
+
+    Streams ``zstd -d`` directly into ``docker load`` with no
+    intermediate uncompressed file.
+    """
+    images_tar_zst = staging / "images.tar.zst"
+
+    if not images_tar_zst.exists():
+        print("No images in bundle; skipping 'docker load'.")
+        return True
+
+    print("Loading images with 'zstd -d | docker load'...")
+    decompress = subprocess.Popen(
+        ["zstd", "-d", "-c", str(images_tar_zst)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    if decompress.stdout is None:
+        print(
+            "Error: 'zstd -d' produced no output pipe.",
+            file=sys.stderr,
+        )
+        return False
+
+    load = subprocess.Popen(
+        ["docker", "load"],
+        stdin=decompress.stdout,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    decompress.stdout.close()
+    dc_rc = decompress.wait()
+    ld_rc = load.wait()
+
+    dc_err = (
+        decompress.stderr.read().decode(errors="replace").strip()
+        if decompress.stderr
+        else ""
+    )
+    load_out = (
+        load.stdout.read().decode(errors="replace").strip() if load.stdout else ""
+    )
+    load_err = (
+        load.stderr.read().decode(errors="replace").strip() if load.stderr else ""
+    )
+
+    if dc_rc != 0 and dc_err:
+        print(dc_err, file=sys.stderr)
+        return False
+
+    if ld_rc != 0:
+        print(load_err, file=sys.stderr)
+        return False
+
+    if load_out:
+        print(load_out)
+
+    return True
+
+
+def _restore_dir(src: Path, dest: Path, *, label: str) -> None:
+    """Move *src* onto *dest*, replacing an existing directory."""
+    if dest.exists():
+        print(f"Replacing existing {label} at {dest}.")
+        rm_with_docker(dest)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(src), str(dest))
+
+
+def handle_import(args) -> bool:
+    """Import a bundle without cloning its CRS repositories."""
+    bundle = Path(args.in_path)
+    if not bundle.exists():
+        print(f"Error: bundle not found: {bundle}", file=sys.stderr)
+        return False
+
+    crs_compose_dir = args.work_dir / "crs_compose"
+    crs_src_base = crs_compose_dir / "crs_src"
+
+    staging_parent = crs_compose_dir
+    staging_parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(dir=staging_parent, prefix=".import-"))
+    try:
+        print(f"Extracting bundle {bundle}...")
+        with tarfile.open(bundle, "r") as tar:
+            tar.extractall(staging, filter="data")
+
+        manifest_file = staging / "export-manifest.json"
+        if not manifest_file.exists():
+            print(
+                "Error: bundle is missing export-manifest.json "
+                "(not produced by 'export'?).",
+                file=sys.stderr,
+            )
+            return False
+        manifest = json.loads(manifest_file.read_text())
+
+        images = manifest.get("images") or []
+        bundle_platform = manifest.get("platform")
+        host_platform = platform.machine()
+        if images and bundle_platform and bundle_platform != host_platform:
+            print(
+                f"Error: bundle was built for '{bundle_platform}' but this host "
+                f"is '{host_platform}'. Docker images are architecture-specific "
+                "and cannot be imported here.",
+                file=sys.stderr,
+            )
+            return False
+
+        if not _load_images(staging):
+            return False
+
+        restored_sources: list[str] = []
+        src_crs_root = staging / "crs_src"
+        if src_crs_root.is_dir():
+            for child in sorted(src_crs_root.iterdir()):
+                if not child.is_dir():
+                    continue
+                dest = crs_src_base / child.name
+                _restore_dir(child, dest, label=f"CRS source '{child.name}'")
+                restored_sources.append(child.name)
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+    summary = []
+    if images:
+        summary.append(f"{len(images)} image(s)")
+    if restored_sources:
+        summary.append(f"{len(restored_sources)} CRS source(s)")
+    restored = " + ".join(summary) if summary else "nothing"
+    print(f"Imported {restored} into {crs_compose_dir}")
+    return True

--- a/oss_crs/src/constants.py
+++ b/oss_crs/src/constants.py
@@ -3,13 +3,20 @@
 LITELLM_IMAGE = "ghcr.io/berriai/litellm-database@sha256:8075b09298dc2453316ebe6152603da34d4b1a0661a3cd756a11191a5b40d59c"  # v1.94.0
 POSTGRES_IMAGE = "postgres@sha256:3a82e1f56c8f0f5616a11103ac3d47e632c3938698946a7ad26da0df1334744a"  # 18.4
 
+# Stable local tags for the internal LiteLLM stack images. ``prepare`` pulls
+# each by its immutable digest and applies the local tag; the run template
+# references these local tags so offline runs resolve them locally.
+OSS_CRS_LITELLM_TAG = "oss-crs-litellm:latest"
+OSS_CRS_POSTGRES_TAG = "oss-crs-postgres:latest"
+
 # Alpine image used by the cleanup helpers (``rm_with_docker`` and the
-# ``oss-crs clean`` size fallback), which shell out to ``docker run --rm alpine``
-# to delete/measure root-owned files during run teardown and clean. ``prepare``
-# pulls this pinned digest once (unconditionally, since cleanup runs regardless
-# of LLM mode) and tags it back to the bare ``alpine`` handle the helpers use, so
+# ``oss-crs clean`` size fallback), which shell out to ``docker run --rm``
+# to delete/measure root-owned files during run teardown and clean.
+# ``prepare`` pulls this pinned digest once (unconditionally, since cleanup
+# runs regardless of LLM mode) and tags it with ``OSS_CRS_ALPINE_TAG`` so
 # offline teardown/clean resolve it locally instead of pulling per invocation.
 ALPINE_IMAGE = "alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b"  # 3.x latest
+OSS_CRS_ALPINE_TAG = "oss-crs-alpine:latest"
 
 # Pinned-digest images pulled (not built) for the internal LiteLLM stack, each
 # mapped to a stable, infra-owned local tag. ``prepare`` pulls each by its
@@ -19,8 +26,8 @@ ALPINE_IMAGE = "alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198
 # the run template still resolve to the same local image, while the tag makes it
 # visible in ``docker images`` and gives it a usable, stable handle.
 OSS_CRS_INTERNAL_LLM_IMAGES = {
-    LITELLM_IMAGE: "oss-crs-litellm:latest",
-    POSTGRES_IMAGE: "oss-crs-postgres:latest",
+    LITELLM_IMAGE: OSS_CRS_LITELLM_TAG,
+    POSTGRES_IMAGE: OSS_CRS_POSTGRES_TAG,
 }
 
 # Internal-LLM-only sidecars that are *built* from oss-crs-infra contexts (as

--- a/oss_crs/src/crs_compose.py
+++ b/oss_crs/src/crs_compose.py
@@ -44,6 +44,7 @@ from .cgroup import (
 )
 from .constants import (
     ALPINE_IMAGE,
+    OSS_CRS_ALPINE_TAG,
     OSS_CRS_INFRA_SIDECAR_IMAGES,
     OSS_CRS_INTERNAL_LLM_IMAGES,
     OSS_CRS_INTERNAL_LLM_SIDECAR_IMAGES,
@@ -775,11 +776,10 @@ class CRSCompose:
         """Pull the pinned alpine cleanup image once, at prepare time.
 
         ``rm_with_docker`` and the ``oss-crs clean`` size fallback shell out to
-        ``docker run --rm ... alpine ...`` to delete/measure root-owned files
-        during run teardown and clean. Those run regardless of LLM mode, so this
-        is pulled unconditionally. The pinned digest is tagged back to the bare
-        ``alpine`` handle the helpers reference (tagging is additive -- the image
-        keeps its RepoDigest), so offline teardown/clean resolve it locally
+        ``docker run --rm ... oss-crs-alpine ...`` to delete/measure root-owned
+        files during run teardown and clean. Those run regardless of LLM mode, so
+        this is pulled unconditionally. The pinned digest is tagged with
+        ``OSS_CRS_ALPINE_TAG`` so offline teardown/clean resolve it locally
         instead of pulling per invocation.
         """
 
@@ -796,7 +796,7 @@ class CRSCompose:
                 ),
             )
         tag_result = subprocess.run(
-            ["docker", "tag", ALPINE_IMAGE, "alpine"],
+            ["docker", "tag", ALPINE_IMAGE, OSS_CRS_ALPINE_TAG],
             capture_output=True,
             text=True,
         )
@@ -805,7 +805,7 @@ class CRSCompose:
                 success=False,
                 error=(
                     f"Failed to tag cleanup image '{ALPINE_IMAGE}' as "
-                    f"'alpine':\n{tag_result.stderr}"
+                    f"'{OSS_CRS_ALPINE_TAG}':\n{tag_result.stderr}"
                 ),
             )
         return TaskResult(success=True)

--- a/oss_crs/src/templates/renderer.py
+++ b/oss_crs/src/templates/renderer.py
@@ -8,12 +8,12 @@ import yaml
 from ..config.crs import CRSType, OSS_CRS_INFRA_PREFIX
 from ..constants import (
     EXCHANGE_DIR_NAMES,
-    LITELLM_IMAGE,
     LITELLM_INTERNAL_URL,
     OSS_CRS_INFRA_SIDECAR_IMAGES,
     OSS_CRS_INTERNAL_LLM_SIDECAR_IMAGES,
+    OSS_CRS_LITELLM_TAG,
+    OSS_CRS_POSTGRES_TAG,
     POSTGRES_HOST,
-    POSTGRES_IMAGE,
     POSTGRES_PORT,
     POSTGRES_USER,
 )
@@ -408,10 +408,10 @@ def render_run_crs_compose_docker_compose(
                 target, build_id, sanitizer, create=False
             )
         ),
-        "litellm_image": LITELLM_IMAGE,
+        "litellm_image": OSS_CRS_LITELLM_TAG,
         "litellm_internal_url": LITELLM_INTERNAL_URL,
         "litellm_spend_report_path": litellm_spend_report_path,
-        "postgres_image": POSTGRES_IMAGE,
+        "postgres_image": OSS_CRS_POSTGRES_TAG,
         "postgres_user": POSTGRES_USER,
         "postgres_port": POSTGRES_PORT,
         "postgres_host": POSTGRES_HOST,

--- a/oss_crs/src/utils.py
+++ b/oss_crs/src/utils.py
@@ -18,7 +18,7 @@ from questionary.prompts.common import InquirerControl, Separator
 from questionary.question import Question
 from rich.console import Console
 
-from .constants import PRESERVED_BUILDER_REPO, PRESERVED_RUNNER_REPO
+from .constants import OSS_CRS_ALPINE_TAG, PRESERVED_BUILDER_REPO, PRESERVED_RUNNER_REPO
 
 
 RAND_CHARS = string.ascii_lowercase + string.digits
@@ -224,7 +224,7 @@ def rm_with_docker(path: Path) -> None:
                 "--rm",
                 "-v",
                 f"{path.parent}:/data",
-                "alpine",
+                OSS_CRS_ALPINE_TAG,
                 "rm",
                 "-rf",
                 f"/data/{path.name}",

--- a/oss_crs/tests/unit/test_cli_clean.py
+++ b/oss_crs/tests/unit/test_cli_clean.py
@@ -7,14 +7,22 @@ Verifies that:
 3. All expected image patterns are correctly matched.
 """
 
+import docker.errors
 import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from oss_crs.src.cli.clean import (
+from oss_crs.src.cli.discovery import (
     discover_build_target_images,
+    discover_infra_images,
     discover_prepare_images,
     discover_run_images,
+)
+from oss_crs.src.constants import (
+    OSS_CRS_ALPINE_TAG,
+    OSS_CRS_DEPS_IMAGE,
+    OSS_CRS_INTERNAL_LLM_IMAGES,
+    OSS_CRS_INTERNAL_LLM_SIDECAR_IMAGES,
 )
 from oss_crs.src.workdir import BuildEntry, RunEntry, WorkDir
 
@@ -79,7 +87,7 @@ class TestBuilderImageDiscovery:
         images = [
             _make_image(["oss-crs-builder:atlantis-c-default-builder-1700000000ab"]),
         ]
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             client = mock_docker.from_env.return_value
             client.images.list.return_value = images
             client.images.get.side_effect = Exception("not called")
@@ -100,7 +108,7 @@ class TestBuilderImageDiscovery:
             # Builder belongs to "roboduck", not "atlantis-c"
             _make_image(["oss-crs-builder:roboduck-default-builder-1700000000ab"]),
         ]
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             client = mock_docker.from_env.return_value
             client.images.list.return_value = images
 
@@ -118,7 +126,7 @@ class TestBuilderImageDiscovery:
             # Correct CRS but wrong build_id
             _make_image(["oss-crs-builder:atlantis-c-default-builder-9999999999zz"]),
         ]
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             client = mock_docker.from_env.return_value
             client.images.list.return_value = images
 
@@ -136,7 +144,7 @@ class TestBuilderImageDiscovery:
             _make_image(["oss-crs-builder:atlantis-c-fuzzer-a-bid1"]),
             _make_image(["oss-crs-builder:atlantis-c-fuzzer-b-bid2"]),
         ]
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             client = mock_docker.from_env.return_value
             client.images.list.return_value = images
 
@@ -158,7 +166,7 @@ class TestBuilderImageDiscovery:
             # Tag starts with "atlantis-c-" which is NOT "atlantis-"
             _make_image(["oss-crs-builder:atlantis-c-default-builder-bid1"]),
         ]
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             client = mock_docker.from_env.return_value
             client.images.list.return_value = images
 
@@ -181,7 +189,7 @@ class TestBuilderImageDiscovery:
         images = [
             _make_image(["oss-crs-builder:atlantis-c-default-builder-bid1"]),
         ]
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             client = mock_docker.from_env.return_value
             client.images.list.return_value = images
 
@@ -208,7 +216,7 @@ class TestSnapshotImageDiscovery:
         snapshot_images = [
             _make_image(["oss-crs-snapshot:pre-atlantis-c-default-builder-bid1"]),
         ]
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             client = mock_docker.from_env.return_value
             client.images.list.side_effect = lambda name=None: (
                 builder_images
@@ -231,7 +239,7 @@ class TestSnapshotImageDiscovery:
         snapshot_images = [
             _make_image(["oss-crs-snapshot:pre-roboduck-default-builder-bid1"]),
         ]
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             client = mock_docker.from_env.return_value
             client.images.list.side_effect = lambda name=None: (
                 snapshot_images if name == "oss-crs-snapshot" else []
@@ -250,7 +258,7 @@ class TestSnapshotImageDiscovery:
         snapshot_images = [
             _make_image(["oss-crs-snapshot:pre-atlantis-c-default-builder-other_bid"]),
         ]
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             client = mock_docker.from_env.return_value
             client.images.list.side_effect = lambda name=None: (
                 snapshot_images if name == "oss-crs-snapshot" else []
@@ -269,7 +277,7 @@ class TestSnapshotImageDiscovery:
         snapshot_images = [
             _make_image(["oss-crs-snapshot:test-bid1"]),
         ]
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             client = mock_docker.from_env.return_value
             client.images.list.side_effect = lambda name=None: (
                 snapshot_images if name == "oss-crs-snapshot" else []
@@ -288,7 +296,7 @@ class TestSnapshotImageDiscovery:
         snapshot_images = [
             _make_image(["oss-crs-snapshot:test-other_bid"]),
         ]
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             client = mock_docker.from_env.return_value
             client.images.list.side_effect = lambda name=None: (
                 snapshot_images if name == "oss-crs-snapshot" else []
@@ -314,7 +322,7 @@ class TestTargetImageDiscovery:
         target = MagicMock()
         target.get_docker_image_name.return_value = "oss-fuzz-target:address"
 
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             client = mock_docker.from_env.return_value
             client.images.list.return_value = []
             client.images.get.return_value = _make_image(["oss-fuzz-target:address"])
@@ -332,9 +340,7 @@ class TestTargetImageDiscovery:
         target = MagicMock()
         target.get_docker_image_name.return_value = "oss-fuzz-target:address"
 
-        import docker.errors
-
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             mock_docker.errors = docker.errors
             client = mock_docker.from_env.return_value
             client.images.list.return_value = []
@@ -350,7 +356,7 @@ class TestTargetImageDiscovery:
             build_ids=["bid1"],
             run_ids=[],
         )
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             client = mock_docker.from_env.return_value
             client.images.list.return_value = []
 
@@ -375,7 +381,7 @@ class TestRunImageDiscovery:
             _make_image(["crs_compose_1700000000ab-crs-atlantis-c:latest"]),
             _make_image(["crs_compose_1700000000ab-litellm:latest"]),
         ]
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             client = mock_docker.from_env.return_value
             client.images.list.return_value = images
 
@@ -396,7 +402,7 @@ class TestRunImageDiscovery:
             _make_image(["crs_compose_other_run-crs-atlantis-c:latest"]),
             _make_image(["unrelated-image:latest"]),
         ]
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             client = mock_docker.from_env.return_value
             client.images.list.return_value = images
 
@@ -410,7 +416,7 @@ class TestRunImageDiscovery:
             build_ids=[],
             run_ids=[],
         )
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             client = mock_docker.from_env.return_value
 
             result = discover_run_images(compose)
@@ -434,7 +440,7 @@ class TestRunImageDiscovery:
                 ]
             ),
         ]
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             client = mock_docker.from_env.return_value
             client.images.list.return_value = images
 
@@ -455,7 +461,7 @@ class TestRunImageDiscovery:
             # "run123" starts with "run1" but is a different run
             _make_image(["crs_compose_run123-svc:latest"]),
         ]
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             client = mock_docker.from_env.return_value
             client.images.list.return_value = images
 
@@ -491,7 +497,7 @@ class TestCrossConfigIsolation:
             _make_image(["oss-crs-builder:atlantis-c-default-builder-bid_a"]),
             _make_image(["oss-crs-builder:roboduck-default-builder-bid_b"]),
         ]
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             client = mock_docker.from_env.return_value
             client.images.list.return_value = all_images
 
@@ -517,7 +523,7 @@ class TestCrossConfigIsolation:
             _make_image(["oss-crs-builder:atlantis-c-default-builder-bid_a"]),
             _make_image(["oss-crs-builder:atlantis-c-default-builder-bid_b"]),
         ]
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             client = mock_docker.from_env.return_value
             client.images.list.return_value = all_images
 
@@ -542,7 +548,7 @@ class TestCrossConfigIsolation:
             _make_image(["crs_compose_run_a-crs:latest"]),
             _make_image(["crs_compose_run_b-crs:latest"]),
         ]
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             client = mock_docker.from_env.return_value
             client.images.list.return_value = all_images
 
@@ -559,6 +565,36 @@ class TestCrossConfigIsolation:
 
 
 class TestPrepareImageDiscovery:
+    def test_infra_images_include_oss_crs_deps(self):
+        crs_compose = MagicMock()
+        crs_compose.crs_list = []
+        crs_compose.llm.exists.return_value = False
+        result = discover_infra_images(crs_compose)
+        assert f"{OSS_CRS_DEPS_IMAGE}:latest" in result
+        assert OSS_CRS_ALPINE_TAG in result
+
+    def test_infra_images_include_internal_llm(self):
+        crs_compose = MagicMock()
+        crs_compose.crs_list = []
+        crs_compose.llm.exists.return_value = True
+        crs_compose.llm.mode = "internal"
+        result = discover_infra_images(crs_compose)
+        for tag in OSS_CRS_INTERNAL_LLM_SIDECAR_IMAGES.values():
+            assert tag in result
+        for tag in OSS_CRS_INTERNAL_LLM_IMAGES.values():
+            assert tag in result
+
+    def test_infra_images_exclude_internal_llm_when_not_internal(self):
+        crs_compose = MagicMock()
+        crs_compose.crs_list = []
+        crs_compose.llm.exists.return_value = True
+        crs_compose.llm.mode = "external"
+        result = discover_infra_images(crs_compose)
+        for tag in OSS_CRS_INTERNAL_LLM_SIDECAR_IMAGES.values():
+            assert tag not in result
+        for tag in OSS_CRS_INTERNAL_LLM_IMAGES.values():
+            assert tag not in result
+
     def test_returns_existing_images_from_bake_tags(self):
         crs = MagicMock()
         crs.name = "atlantis-c"
@@ -567,9 +603,7 @@ class TestPrepareImageDiscovery:
         compose = MagicMock()
         compose.crs_list = [crs]
 
-        import docker.errors
-
-        with patch("oss_crs.src.cli.clean.docker") as mock_docker:
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
             mock_docker.errors = docker.errors
             client = mock_docker.from_env.return_value
 
@@ -599,11 +633,18 @@ class TestPrepareImageDiscovery:
         compose.crs_list = [crs_bad, crs_ok]
 
         with (
-            patch("oss_crs.src.cli.clean.docker") as mock_docker,
-            patch("oss_crs.src.cli.clean.log_warning") as mock_warn,
+            patch("oss_crs.src.cli.discovery.docker") as mock_docker,
+            patch("oss_crs.src.cli.discovery.log_warning") as mock_warn,
         ):
+            mock_docker.errors = docker.errors
             client = mock_docker.from_env.return_value
-            client.images.get.return_value = _make_image(["roboduck:latest"])
+
+            def fake_get(tag):
+                if tag == "roboduck:latest":
+                    return _make_image([tag])
+                raise docker.errors.ImageNotFound("nope")
+
+            client.images.get.side_effect = fake_get
 
             result = discover_prepare_images(compose)
 
@@ -613,7 +654,7 @@ class TestPrepareImageDiscovery:
         # Healthy CRS images are still discovered
         assert result == ["roboduck:latest"]
 
-    def test_empty_when_no_bake_tags(self):
+    def test_empty_when_no_prepare_images_exist(self):
         crs = MagicMock()
         crs.name = "atlantis-c"
         crs.get_bake_image_tags.return_value = []
@@ -621,7 +662,122 @@ class TestPrepareImageDiscovery:
         compose = MagicMock()
         compose.crs_list = [crs]
 
-        with patch("oss_crs.src.cli.clean.docker"):
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
+            mock_docker.errors = docker.errors
+            mock_docker.from_env.return_value.images.get.side_effect = (
+                docker.errors.ImageNotFound("nope")
+            )
+            result = discover_prepare_images(compose)
+
+        assert result == []
+
+    def test_includes_existing_infra_images(self):
+        compose = MagicMock()
+        compose.crs_list = []
+        compose.llm.exists.return_value = False
+
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
+            client = mock_docker.from_env.return_value
+            client.images.get.return_value = _make_image(["oss-crs-deps:latest"])
+
+            result = discover_prepare_images(compose)
+
+        assert "oss-crs-deps:latest" in result
+
+    def test_includes_existing_target_independent_runner_images(self):
+        """Target-independent run-phase images built during prepare are discovered."""
+        from oss_crs.src.config.crs import CRSRunPhaseModule
+
+        crs = MagicMock()
+        crs.name = "atlantis-c"
+        crs.get_bake_image_tags.return_value = []
+
+        independent_module = CRSRunPhaseModule(
+            dockerfile="oss-crs/dockerfiles/runner.Dockerfile",
+            target_dependent=False,
+        )
+        dependent_module = CRSRunPhaseModule(
+            dockerfile="oss-crs/dockerfiles/lsp.Dockerfile",
+            target_dependent=True,
+        )
+        crs.config.crs_run_phase.modules = {
+            "fuzzer": independent_module,
+            "lsp": dependent_module,
+        }
+
+        compose = MagicMock()
+        compose.crs_list = [crs]
+        compose.llm.exists.return_value = False
+
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
+            mock_docker.errors = docker.errors
+            client = mock_docker.from_env.return_value
+
+            runner_tag = "oss-crs-runner:atlantis-c-fuzzer"
+            client.images.get.side_effect = lambda tag: (
+                _make_image([tag])
+                if tag == runner_tag
+                else (_ for _ in ()).throw(docker.errors.ImageNotFound("nope"))
+            )
+
+            result = discover_prepare_images(compose)
+
+        assert runner_tag in result
+
+    def test_excludes_target_dependent_runner_images(self):
+        """Target-dependent runner images are not included in prepare images."""
+        from oss_crs.src.config.crs import CRSRunPhaseModule
+
+        crs = MagicMock()
+        crs.name = "atlantis-c"
+        crs.get_bake_image_tags.return_value = []
+
+        dependent_module = CRSRunPhaseModule(
+            dockerfile="oss-crs/dockerfiles/lsp.Dockerfile",
+            target_dependent=True,
+        )
+        crs.config.crs_run_phase.modules = {
+            "lsp": dependent_module,
+        }
+
+        compose = MagicMock()
+        compose.crs_list = [crs]
+        compose.llm.exists.return_value = False
+
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
+            mock_docker.errors = docker.errors
+            client = mock_docker.from_env.return_value
+            client.images.get.side_effect = docker.errors.ImageNotFound("nope")
+
+            result = discover_prepare_images(compose)
+
+        assert result == []
+
+    def test_skips_missing_target_independent_runner_images(self):
+        """Missing runner images are not included in the result."""
+        from oss_crs.src.config.crs import CRSRunPhaseModule
+
+        crs = MagicMock()
+        crs.name = "atlantis-c"
+        crs.get_bake_image_tags.return_value = []
+
+        independent_module = CRSRunPhaseModule(
+            dockerfile="oss-crs/dockerfiles/runner.Dockerfile",
+            target_dependent=False,
+        )
+        crs.config.crs_run_phase.modules = {
+            "fuzzer": independent_module,
+        }
+
+        compose = MagicMock()
+        compose.crs_list = [crs]
+        compose.llm.exists.return_value = False
+
+        with patch("oss_crs.src.cli.discovery.docker") as mock_docker:
+            mock_docker.errors = docker.errors
+            client = mock_docker.from_env.return_value
+            client.images.get.side_effect = docker.errors.ImageNotFound("nope")
+
             result = discover_prepare_images(compose)
 
         assert result == []

--- a/oss_crs/tests/unit/test_cli_export.py
+++ b/oss_crs/tests/unit/test_cli_export.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: MIT
+"""Unit tests for exporting prepared images and CRS source."""
+
+import json
+import tarfile
+from pathlib import Path
+from types import SimpleNamespace
+
+from oss_crs.src.cli import export as export_mod
+from oss_crs.src.cli.export import handle_export
+
+
+def _make_compose(crs_list: list | None = None) -> SimpleNamespace:
+    return SimpleNamespace(crs_list=crs_list or [])
+
+
+def _make_crs(tmp_path: Path, name: str) -> SimpleNamespace:
+    crs_path = tmp_path / "crs_src" / name
+    crs_path.mkdir(parents=True, exist_ok=True)
+    (crs_path / "build.sh").write_text("#!/bin/sh\n")
+    return SimpleNamespace(name=name, crs_path=crs_path)
+
+
+def _members(tar_path: Path) -> set[str]:
+    with tarfile.open(tar_path, "r") as tar:
+        return {member.name for member in tar.getmembers()}
+
+
+def test_export_source_without_images(tmp_path: Path, monkeypatch) -> None:
+    compose = _make_compose([_make_crs(tmp_path, "crs-codex")])
+    monkeypatch.setattr(export_mod, "discover_prepare_images", lambda _c: [])
+    out = tmp_path / "prepared.tar"
+
+    assert handle_export(SimpleNamespace(out=str(out)), compose) is True
+    assert "images.tar" not in _members(out)
+    assert "crs_src/crs-codex/build.sh" in _members(out)
+
+    with tarfile.open(out, "r") as tar:
+        manifest = json.loads(tar.extractfile("export-manifest.json").read())
+    assert manifest["images"] == []
+    assert manifest["crs_sources"] == ["crs-codex"]
+    assert "libcrs" not in manifest
+
+
+def test_export_includes_images_and_source(tmp_path: Path, monkeypatch) -> None:
+    compose = _make_compose([_make_crs(tmp_path, "crs-codex")])
+    monkeypatch.setattr(
+        export_mod,
+        "discover_prepare_images",
+        lambda _c: ["oss-crs-deps:latest", "crs-image:latest"],
+    )
+
+    def fake_stream(tags, dest):
+        assert tags == ["oss-crs-deps:latest", "crs-image:latest"]
+        Path(dest).write_bytes(b"FAKE_DOCKER_SAVE")
+        return True
+
+    monkeypatch.setattr(export_mod, "_stream_images", fake_stream)
+    out = tmp_path / "prepared.tar"
+
+    assert handle_export(SimpleNamespace(out=str(out)), compose) is True
+    members = _members(out)
+    assert "images.tar.zst" in members
+    assert "crs_src/crs-codex/build.sh" in members
+    assert not any(name.startswith("libcrs/") for name in members)
+
+    with tarfile.open(out, "r") as tar:
+        manifest = json.loads(tar.extractfile("export-manifest.json").read())
+    assert manifest["images"] == ["oss-crs-deps:latest", "crs-image:latest"]
+    assert manifest["crs_sources"] == ["crs-codex"]
+    assert manifest["compression"] == "zstd"
+
+
+def test_export_nothing_to_export(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(export_mod, "discover_prepare_images", lambda _c: [])
+    out = tmp_path / "prepared.tar"
+
+    assert handle_export(SimpleNamespace(out=str(out)), _make_compose()) is False
+    assert not out.exists()
+
+
+def test_export_save_failure_returns_false(tmp_path: Path, monkeypatch) -> None:
+    compose = _make_compose([_make_crs(tmp_path, "crs-codex")])
+    monkeypatch.setattr(export_mod, "discover_prepare_images", lambda _c: ["img:1"])
+    monkeypatch.setattr(export_mod, "_stream_images", lambda tags, dest: False)
+    out = tmp_path / "prepared.tar"
+
+    assert handle_export(SimpleNamespace(out=str(out)), compose) is False
+    assert not out.exists()

--- a/oss_crs/tests/unit/test_cli_import.py
+++ b/oss_crs/tests/unit/test_cli_import.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: MIT
+"""Unit tests for importing Docker images and CRS source."""
+
+import json
+import argparse
+import shutil
+import tarfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from oss_crs.src.cli import import_cmd as import_mod
+from oss_crs.src.cli.crs_compose import DEFAULT_WORK_DIR, add_import_command
+from oss_crs.src.cli.import_cmd import handle_import
+
+
+@pytest.fixture(autouse=True)
+def _stub_rm_with_docker(monkeypatch) -> list[Path]:
+    removed: list[Path] = []
+
+    def fake_rm(path: Path) -> None:
+        removed.append(Path(path))
+        shutil.rmtree(path, ignore_errors=True)
+
+    monkeypatch.setattr(import_mod, "rm_with_docker", fake_rm)
+    return removed
+
+
+def _capture_load(monkeypatch) -> list[Path]:
+    loaded: list[Path] = []
+
+    def fake_load(staging: Path) -> bool:
+        loaded.append(Path(staging))
+        return True
+
+    monkeypatch.setattr(import_mod, "_load_images", fake_load)
+    return loaded
+
+
+def _make_bundle(
+    path: Path,
+    *,
+    machine: str = "x86_64",
+    images: bool = True,
+    crs_sources: tuple[str, ...] = ("crs-foo",),
+    with_manifest: bool = True,
+) -> None:
+    stage = path.parent / f".stage-{path.name}"
+    stage.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "oss_crs_export_version": 1,
+        "platform": machine,
+        "images": ["oss-crs-deps:latest", "crs-image:latest"] if images else [],
+        "crs_sources": list(crs_sources),
+        "compression": "zstd",
+    }
+
+    with tarfile.open(path, "w") as tar:
+        if with_manifest:
+            manifest_file = stage / "export-manifest.json"
+            manifest_file.write_text(json.dumps(manifest))
+            tar.add(manifest_file, arcname="export-manifest.json")
+        if images:
+            images_tar = stage / "images.tar.zst"
+            images_tar.write_bytes(b"FAKE_DOCKER_SAVE")
+            tar.add(images_tar, arcname="images.tar.zst")
+        for name in crs_sources:
+            src = stage / "crs_src" / name
+            src.mkdir(parents=True, exist_ok=True)
+            (src / "build.sh").write_text("#!/bin/sh\n")
+            tar.add(src, arcname=f"crs_src/{name}")
+
+
+def _args(bundle: Path, tmp_path: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        in_path=str(bundle),
+        work_dir=tmp_path / "work",
+    )
+
+
+def _crs_src_base(tmp_path: Path) -> Path:
+    return tmp_path / "work" / "crs_compose" / "crs_src"
+
+
+def test_import_restores_images_and_sources(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(import_mod.platform, "machine", lambda: "x86_64")
+    loaded = _capture_load(monkeypatch)
+    bundle = tmp_path / "prepared.tar"
+    _make_bundle(bundle, crs_sources=("crs-foo", "crs-bar"))
+
+    assert handle_import(_args(bundle, tmp_path)) is True
+    assert len(loaded) == 1
+    base = _crs_src_base(tmp_path)
+    assert (base / "crs-foo" / "build.sh").exists()
+    assert (base / "crs-bar" / "build.sh").exists()
+
+
+def test_import_missing_bundle(tmp_path: Path, monkeypatch) -> None:
+    assert handle_import(_args(tmp_path / "missing.tar", tmp_path)) is False
+
+
+def test_import_missing_manifest(tmp_path: Path, monkeypatch) -> None:
+    _capture_load(monkeypatch)
+    bundle = tmp_path / "bad.tar"
+    _make_bundle(bundle, with_manifest=False)
+
+    assert handle_import(_args(bundle, tmp_path)) is False
+
+
+def test_import_image_platform_mismatch_errors(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(import_mod.platform, "machine", lambda: "x86_64")
+    _capture_load(monkeypatch)
+    bundle = tmp_path / "arm.tar"
+    _make_bundle(bundle, machine="aarch64")
+
+    assert handle_import(_args(bundle, tmp_path)) is False
+    assert not (_crs_src_base(tmp_path) / "crs-foo").exists()
+
+
+def test_import_source_only_allows_platform_mismatch(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(import_mod.platform, "machine", lambda: "x86_64")
+    loaded = _capture_load(monkeypatch)
+    bundle = tmp_path / "source.tar"
+    _make_bundle(bundle, machine="aarch64", images=False)
+
+    assert handle_import(_args(bundle, tmp_path)) is True
+    # _load_images is still called, but the bundle has no images.tar.zst,
+    # so it should return True without actually loading anything.
+    assert len(loaded) == 1
+    assert (_crs_src_base(tmp_path) / "crs-foo" / "build.sh").exists()
+
+
+def test_import_replaces_existing_source_with_docker(
+    tmp_path: Path, monkeypatch, _stub_rm_with_docker: list[Path]
+) -> None:
+    monkeypatch.setattr(import_mod.platform, "machine", lambda: "x86_64")
+    _capture_load(monkeypatch)
+    bundle = tmp_path / "prepared.tar"
+    _make_bundle(bundle)
+    source = _crs_src_base(tmp_path) / "crs-foo"
+    source.mkdir(parents=True)
+    (source / "stale.txt").write_text("old")
+
+    assert handle_import(_args(bundle, tmp_path)) is True
+    assert source in _stub_rm_with_docker
+    assert not (source / "stale.txt").exists()
+    assert (source / "build.sh").exists()
+
+
+def test_import_load_failure_returns_false(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(import_mod.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(import_mod, "_load_images", lambda _path: False)
+    bundle = tmp_path / "prepared.tar"
+    _make_bundle(bundle)
+
+    assert handle_import(_args(bundle, tmp_path)) is False
+
+
+def test_import_cli_does_not_require_compose_file() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    add_import_command(subparsers)
+
+    args = parser.parse_args(["import", "--in", "prepared.tar"])
+
+    assert args.in_path == "prepared.tar"
+    assert args.work_dir == DEFAULT_WORK_DIR
+    assert not hasattr(args, "compose_file")

--- a/oss_crs/tests/unit/test_infra_sidecar_images.py
+++ b/oss_crs/tests/unit/test_infra_sidecar_images.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 from oss_crs.src.constants import (
     ALPINE_IMAGE,
+    OSS_CRS_ALPINE_TAG,
     OSS_CRS_INFRA_SIDECAR_IMAGES,
     OSS_CRS_INTERNAL_LLM_IMAGES,
     OSS_CRS_INTERNAL_LLM_SIDECAR_IMAGES,
@@ -210,10 +211,10 @@ def test_cleanup_image_is_pulled_by_digest_and_tagged_alpine():
         result = _pull_cleanup_image()
 
     assert result.success is True
-    # One `docker pull <digest>` and one `docker tag <digest> alpine`.
+    # One `docker pull <digest>` and one `docker tag <digest> <stable tag>`.
     assert calls == [
         ["docker", "pull", ALPINE_IMAGE],
-        ["docker", "tag", ALPINE_IMAGE, "alpine"],
+        ["docker", "tag", ALPINE_IMAGE, OSS_CRS_ALPINE_TAG],
     ]
 
 


### PR DESCRIPTION
## Summary

Describe what changed and why.

Added a export subcommand:
- Exports docker images pulled/built in the prepare phase and the CRS source code as a tar file, where the docker images are compressed using the zstd algorithm. Streaming is used to reduce peak file size.

Added an import subcommand:
- Restores OSS-CRS's state from a tar file generated using the export subcommand. Streaming is used to load the docker images.

## User Impact

- [X] User-facing change
- [ ] Internal-only change

If user-facing, describe CLI/API/config/docs impact and migration steps.

## Release Note / Changelog

- [x] I updated `CHANGELOG.md` (`[Unreleased]`) for user-facing changes
- [ ] No changelog entry needed (internal-only refactor/test/chore)

If this PR includes deprecation or breaking behavior, include:
- replacement path for users
- planned removal version/release window

## Validation

List tests/checks run and their results.

## Checklist

- [x] I followed Conventional Commits
- [x] I updated docs for behavior/config/CLI changes
- [x] I added/updated tests for behavior changes
- [x] I considered backward compatibility and migration impact
