### PR TITLE
Change the default for target_dependent to be true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ stricter subset of Keep a Changelog).
 
 ### Changed
 
+- Run-phase modules now default to `target_dependent: true`, so their images are built once per target during `build-target`. Set `target_dependent: false` for modules that can be built once during `prepare`.
 - `--offline` flag for all subcommands: disables git fetch
 - `libCRS` `apply_patch_build`: builder-side errors returned before a `rebuild_id` is assigned are now written to `<response_dir>/stderr.log` instead of being dropped. The public signature (`apply_patch_build(patch_path, response_dir, ...)`) and the positional shell form (`apply-patch-build <patch> <response_dir>`) are unchanged; `apply_patch_test` and `run-pov` are likewise unchanged.
 

--- a/docs/config/crs.md
+++ b/docs/config/crs.md
@@ -172,13 +172,13 @@ Every run module is built from a `dockerfile` by the framework ahead of the run 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `dockerfile` | `string` | Yes | - | Path to the Dockerfile (must contain "Dockerfile" or end with `.Dockerfile`). Can use `oss-crs-infra:` prefix for framework-provided services. |
-| `target_dependent` | `bool` | No | `false` | Whether the image depends on the specific target. `false` → built once during **prepare**; `true` → built during **build-target**, once per target. |
+| `target_dependent` | `bool` | No | `true` | Whether the image depends on the specific target. `true` → built during **build-target**, once per target; `false` → built once during **prepare**. |
 | `additional_env` | `dict[string, string]` | No | `{}` | Additional environment variables to pass to the module. Keys must match `[A-Za-z_][A-Za-z0-9_]*`. |
 
 #### Build phase: `target_dependent`
 
-- **`target_dependent: false`** (default) — the image is *target-independent* (e.g. `FROM` a fixed base; the target is mounted at run time, not baked in). The framework builds it once during the **prepare** phase and tags it `oss-crs-runner:<crs>-<module>`. The `crs_version` build-arg and the `libcrs` build context are provided.
-- **`target_dependent: true`** — the image depends on the specific target (e.g. `FROM ${target_base_image}`). The framework builds it during the **build-target** phase, once per target, and tags it `oss-crs-runner:<crs>-<module>-<target_hash>`. In addition to `crs_version` and `libcrs`, the `target_base_image` and `base_runner_image` build-args are provided.
+- **`target_dependent: true`** (default) — the image depends on the specific target (e.g. `FROM ${target_base_image}`). The framework builds it during the **build-target** phase, once per target, and tags it `oss-crs-runner:<crs>-<module>-<target_hash>`. In addition to `crs_version` and `libcrs`, the `target_base_image` and `base_runner_image` build-args are provided.
+- **`target_dependent: false`** — the image is *target-independent* (e.g. `FROM` a fixed base; the target is mounted at run time, not baked in). The framework builds it once during the **prepare** phase and tags it `oss-crs-runner:<crs>-<module>`. The `crs_version` build-arg and the `libcrs` build context are provided.
 
 The `oss-crs-runner:` prefix keeps these images out of the run-time teardown sweep. The images must be resolvable at run time — present locally (from prepare/build-target) or pullable from a registry when the run is online.
 
@@ -186,16 +186,16 @@ The `oss-crs-runner:` prefix keeps these images out of the run-time teardown swe
 
 ```yaml
 crs_run_phase:
-  # Target-independent: built once by prepare.
+  # Target-independent: opt out of the default and build once during prepare.
   fuzzer:
     dockerfile: oss-crs/dockerfiles/runner.Dockerfile
+    target_dependent: false
     additional_env:
       RUNNING_TIME_ENV: "XXX"
-  # Target-dependent: built once per target by build-target
+  # Target-dependent (default): built once per target by build-target
   # (e.g. its Dockerfile is `FROM ${target_base_image}`).
   lsp:
     dockerfile: oss-crs/dockerfiles/lsp.Dockerfile
-    target_dependent: true
 ```
 
 **Note:** Builder and runner sidecars are injected automatically by the framework during the run phase. CRS developers do not need to declare them in `crs_run_phase`. The `BUILDER_MODULE` environment variable is set automatically.

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -102,7 +102,7 @@ Every CRS repository contains an `oss-crs/crs.yaml` file that declares:
 
 - **Prepare phase** — An HCL file for `docker buildx bake` to build the CRS images
 - **Target build phase** — A list of build steps, each with a Dockerfile and expected outputs
-- **Run phase** — A set of named modules (containers) that constitute the CRS at runtime. Each module is built from a `dockerfile:` ahead of the run (by prepare for target-independent modules, or build-target for `target_dependent: true` modules) and consumed read-only at run time (see [docs/config/crs.md](../config/crs.md#crsrunphasemodule))
+- **Run phase** — A set of named modules (containers) that constitute the CRS at runtime. By default, each module is built by build-target once per target. Modules that set `target_dependent: false` are built once during prepare. Run images are consumed read-only (see [docs/config/crs.md](../config/crs.md#crsrunphasemodule)).
 - **Supported targets** — Languages, sanitizers, and architectures the CRS supports
 - **Required LLMs** — Model names the CRS needs (validated against the LiteLLM config before launch)
 - **Required Inputs** — Input channels the CRS depends on (validated before container launch; e.g., `diff`, `bug-candidate`)

--- a/oss_crs/src/config/crs.py
+++ b/oss_crs/src/config/crs.py
@@ -104,20 +104,20 @@ class CRSRunPhaseModule(BaseModel):
     A module's run image is always *prebuilt* by the framework and consumed
     read-only at run time. The build phase is selected by ``target_dependent``:
 
-    - ``target_dependent: false`` (default): the image is target-independent
-      and is built once during the prepare phase. Its tag is derived by the
-      framework as ``oss-crs-runner:<crs>-<module>``.
-    - ``target_dependent: true``: the image depends on the specific target
+    - ``target_dependent: true`` (default): the image depends on the specific target
       (e.g. ``FROM ${target_base_image}``) and is built during the
       build-target phase, keyed by the target hash. Its tag is derived as
       ``oss-crs-runner:<crs>-<module>-<target_hash>``.
+    - ``target_dependent: false``: the image is target-independent and is built
+      once during the prepare phase. Its tag is derived by the framework as
+      ``oss-crs-runner:<crs>-<module>``.
 
     ``dockerfile`` is always required and may be a file path or an
     ``oss-crs-infra:<module>`` reference.
     """
 
     dockerfile: str
-    target_dependent: bool = False
+    target_dependent: bool = True
     additional_env: dict[str, str] = Field(default_factory=dict)
 
     @field_validator("dockerfile")

--- a/oss_crs/tests/unit/config/test_crs.py
+++ b/oss_crs/tests/unit/config/test_crs.py
@@ -68,16 +68,16 @@ class TestCRSRunPhaseModule:
         with pytest.raises(ValidationError):
             CRSRunPhaseModule()
 
-    def test_module_defaults_to_target_independent(self):
-        """Without target_dependent the image is built at prepare."""
+    def test_module_defaults_to_target_dependent(self):
+        """Without target_dependent the image is built during build-target."""
         module = CRSRunPhaseModule(dockerfile="run.Dockerfile")
         assert module.dockerfile == "run.Dockerfile"
-        assert module.target_dependent is False
-
-    def test_module_target_dependent_flag(self):
-        """target_dependent opts the module into the build-target phase."""
-        module = CRSRunPhaseModule(dockerfile="run.Dockerfile", target_dependent=True)
         assert module.target_dependent is True
+
+    def test_module_target_independent_flag(self):
+        """target_dependent: false opts the module into the prepare phase."""
+        module = CRSRunPhaseModule(dockerfile="run.Dockerfile", target_dependent=False)
+        assert module.target_dependent is False
 
     def test_module_accepts_infra_reference(self):
         """An oss-crs-infra:<module> reference is a valid dockerfile."""

--- a/oss_crs/tests/unit/test_crs_prepare.py
+++ b/oss_crs/tests/unit/test_crs_prepare.py
@@ -327,7 +327,7 @@ def test_prepare_no_pull_skips_pull_and_builds(tmp_path):
 
 def _write_run_module_crs_yaml(crs_root, *, target_dependent: bool):
     """A crs.yaml whose single run module is built directly from a Dockerfile."""
-    flag = "\n            target_dependent: true" if target_dependent else ""
+    flag = f"\n            target_dependent: {str(target_dependent).lower()}"
     crs_yaml = textwrap.dedent(
         f"""\
         name: test-crs
@@ -465,8 +465,8 @@ def test_target_dependent_run_modules_selects_flagged_module(tmp_path):
     assert [name for name, _ in modules] == ["lsp"]
 
 
-def test_target_dependent_run_modules_excludes_default_modules(tmp_path):
-    """Default (target-independent) run modules are built by prepare."""
+def test_target_dependent_run_modules_excludes_opted_out_modules(tmp_path):
+    """Explicitly target-independent run modules are built by prepare."""
     crs = _make_run_module_crs(tmp_path, target_dependent=False)
     assert crs._CRS__target_dependent_run_modules() == []
     independent = crs._CRS__target_independent_run_modules()

--- a/oss_crs/tests/unit/test_renderer_run_compose.py
+++ b/oss_crs/tests/unit/test_renderer_run_compose.py
@@ -133,7 +133,7 @@ def _render(crs_compose, target, tmp_path: Path):
 def test_target_independent_module_renders_consume_only_image(
     monkeypatch, tmp_path: Path
 ) -> None:
-    """A default (target_dependent: false) run module is consume-only.
+    """A target-independent (target_dependent: false) run module is consume-only.
 
     The run compose references the prepare-built image by its framework-derived
     tag (``oss-crs-runner:<crs>-<module>``) and emits no ``build:`` block; the


### PR DESCRIPTION
## Summary

Describe what changed and why.

Set the default for target_dependent to be true so that runtime images are conservatively built during the build-target step, not prepare.


## User Impact

- [X] User-facing change
- [ ] Internal-only change

If user-facing, describe CLI/API/config/docs impact and migration steps.

## Release Note / Changelog

- [X] I updated `CHANGELOG.md` (`[Unreleased]`) for user-facing changes
- [ ] No changelog entry needed (internal-only refactor/test/chore)

If this PR includes deprecation or breaking behavior, include:
- replacement path for users
- planned removal version/release window

## Validation

List tests/checks run and their results.

All tests in oss_crs/tests passed

## Checklist

- [X] I followed Conventional Commits
- [X] I updated docs for behavior/config/CLI changes
- [X] I added/updated tests for behavior changes
- [X] I considered backward compatibility and migration impact
