### PR TITLE
chore(deps): update fastapi requirement to >=0.140.13 in the sidecars

### DIFF
--- a/oss-crs-infra/builder-sidecar/requirements.txt
+++ b/oss-crs-infra/builder-sidecar/requirements.txt
@@ -1,4 +1,4 @@
-fastapi>=0.140.9
+fastapi>=0.140.13
 uvicorn>=0.51.0
 docker>=7.2.0
 pydantic>=2.13.4

--- a/oss-crs-infra/runner-sidecar/requirements.txt
+++ b/oss-crs-infra/runner-sidecar/requirements.txt
@@ -1,4 +1,4 @@
-fastapi>=0.140.9
+fastapi>=0.140.13
 uvicorn>=0.51.0
 pydantic>=2.13.4
 python-multipart>=0.0.32


### PR DESCRIPTION
Restores the bump from Dependabot PRs #326 and #340, which were closed by mistake during the #343 cleanup. Dependabot had rebased both onto a newer target (>=0.140.13) rather than superseding them, so they were still live; their branches were deleted on close and could not be reopened.

Same change both PRs proposed, recovered from their retained diffs.

## Summary

Describe what changed and why.

## User Impact

- [ ] User-facing change
- [x] Internal-only change

If user-facing, describe CLI/API/config/docs impact and migration steps.

## Release Note / Changelog

- [ ] I updated `CHANGELOG.md` (`[Unreleased]`) for user-facing changes
- [x] No changelog entry needed (internal-only refactor/test/chore)

If this PR includes deprecation or breaking behavior, include:
- replacement path for users
- planned removal version/release window

## Validation

List tests/checks run and their results.

## Checklist

- [ ] I followed Conventional Commits
- [ ] I updated docs for behavior/config/CLI changes
- [ ] I added/updated tests for behavior changes
- [ ] I considered backward compatibility and migration impact
