### PR TITLE
Log token usage in LiteLLM internal mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ stricter subset of Keep a Changelog).
 - `--offline` flag for all subcommands: disables git fetch
 - `oss-crs build-target` now validates `--bug-candidate`/`--bug-candidate-dir` the same way `oss-crs run` does: a missing path, or a directory passed to `--bug-candidate` (or a file passed to `--bug-candidate-dir`), fails before any container starts instead of being silently ignored.
 - `libCRS` `apply_patch_build`: builder-side errors returned before a `rebuild_id` is assigned are now written to `<response_dir>/stderr.log` instead of being dropped. The public signature (`apply_patch_build(patch_path, response_dir, ...)`) and the positional shell form (`apply-patch-build <patch> <response_dir>`) are unchanged; `apply_patch_test` and `run-pov` are likewise unchanged.
+- Added per-CRS token tracking (`prompt_tokens`/`completion_tokens`) alongside dollar spend.
 
 ### Added
 - `oss-crs list-harnesses --fuzz-proj-path <PATH_TO_PROJ>` — builds an OSS-Fuzz project through its default Docker compile path and lists its runnable fuzz harnesses, reusing cached build artifacts until the project inputs or repository HEAD change.

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -212,6 +212,20 @@ LiteLLM integration modes:
 - **External mode**: OSS-CRS injects externally provided `OSS_CRS_LLM_API_URL` / `OSS_CRS_LLM_API_KEY_FILE`, and does not start internal LiteLLM sidecars.
 - **Disabled mode** (`llm_config: null`): OSS-CRS performs no LiteLLM validation or sidecar setup.
 
+#### Spend and token reporting
+
+`litellm-key-gen` polls LiteLLM every few seconds and writes a host-recoverable `litellm-spend-report.json` per run (`<run_dir>/litellm-spend-report.json`):
+
+```json
+{"totals": {"credits_used": 0.0, "prompt_tokens": 251234,
+            "completion_tokens": 70112},
+ "crs": {"<crs-name>": {<same three fields>}},
+ "updated_at": 1788559707}
+```
+
+- `credits_used` is determined by the number/kind of tokens and LiteLLM's model cost map. `prompt_tokens`/`completion_tokens` come straight from provider `usage` in the spend logs. The total number of tokens is always prompt + completion. Models missing from the cost map report `credits_used == 0` alongside real token counts.
+- The report lags live traffic by at most one poll interval: the sidecar performs a final forced poll on shutdown.
+
 ### Pinned Infrastructure Images
 
 The LiteLLM and PostgreSQL container images are pinned by digest in

--- a/oss-crs-infra/litellm-key-gen/main.py
+++ b/oss-crs-infra/litellm-key-gen/main.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
+import hashlib
 import json
 import os
 import signal
 import time
+from datetime import datetime, timedelta, timezone
+
 import yaml
 import requests
 
@@ -106,26 +109,120 @@ def get_key_spend(api_key: str) -> float:
         return 0.0
 
 
-def collect_spend_summary(key_requests: dict[str, dict]) -> dict:
-    """Build spend summary by querying per-key spend from LiteLLM."""
-    crs_summary: dict[str, dict[str, float]] = {}
-    total = 0.0
+def _today_str() -> str:
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _end_date_str() -> str:
+    """Exclusive window end for spend-log queries.
+
+    LiteLLM treats ``end_date`` as exclusive: querying with
+    ``start_date == end_date == today`` always returns zero rows, so the
+    end of the window must be tomorrow to include today's traffic.
+    """
+    return (datetime.now(timezone.utc).date() + timedelta(days=1)).isoformat()
+
+
+def get_key_tokens(
+    api_key: str,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> tuple[int, int]:
+    """Fetch cumulative (prompt, completion) tokens for a key.
+
+    Sums ``prompt_tokens``/``completion_tokens`` over this key's rows in
+    LiteLLM's spend logs (provider ``usage`` verbatim), independent of the
+    price map — so models missing from the cost map still report tokens
+    while ``spend`` stays 0. Rows are matched by key hash, the form
+    LiteLLM stores in ``api_key``. Fail-open: any error yields (0, 0) so
+    dollar polling never breaks.
+    """
+    if not api_key:
+        return (0, 0)
+    headers = {
+        "Authorization": f"Bearer {LITELLM_MASTER_KEY}",
+    }
+    start = start_date or _today_str()
+    end = end_date or _end_date_str()
+    try:
+        key_hash = hashlib.sha256(api_key.encode()).hexdigest()
+        response = requests.get(
+            f"{LITELLM_API_URL}/spend/logs",
+            headers=headers,
+            params={"start_date": start, "end_date": end, "summarize": "false"},
+            timeout=30,
+        )
+        response.raise_for_status()
+        prompt = 0
+        completion = 0
+        for row in response.json():
+            if row.get("api_key") not in (api_key, key_hash):
+                continue
+            prompt += int(row.get("prompt_tokens", 0) or 0)
+            completion += int(row.get("completion_tokens", 0) or 0)
+        return prompt, completion
+    except Exception as e:
+        print(f"Error fetching token usage for key: {e}")
+        return (0, 0)
+
+
+def collect_spend_summary(
+    key_requests: dict[str, dict],
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> dict:
+    """Build spend summary by querying per-key spend and tokens from LiteLLM."""
+    crs_summary: dict[str, dict[str, float | int]] = {}
+    total_spend = 0.0
+    total_prompt = 0
+    total_completion = 0
+    start = start_date or _today_str()
+    end = end_date or _end_date_str()
     for crs_name, info in key_requests.items():
         api_key = str(info.get("api_key", ""))
         spend = get_key_spend(api_key) if api_key else 0.0
-        crs_summary[crs_name] = {"credits_used": round(spend, 6)}
-        total += spend
+        prompt, completion = get_key_tokens(api_key, start, end) if api_key else (0, 0)
+        crs_summary[crs_name] = {
+            "credits_used": round(spend, 6),
+            "prompt_tokens": prompt,
+            "completion_tokens": completion,
+        }
+        total_spend += spend
+        total_prompt += prompt
+        total_completion += completion
     return {
-        "totals": {"credits_used": round(total, 6)},
+        "totals": {
+            "credits_used": round(total_spend, 6),
+            "prompt_tokens": total_prompt,
+            "completion_tokens": total_completion,
+        },
         "crs": crs_summary,
         "updated_at": int(time.time()),
     }
 
 
 def write_spend_summary(summary: dict) -> None:
-    with open(SPEND_REPORT_PATH, "w") as f:
+    """Write the spend summary atomically.
+
+    A SIGKILL landing mid-write must never leave a truncated report behind
+    (readers turn that into zeros), so the payload goes to a temp file in
+    the same directory first and is moved into place with os.replace.
+    """
+    tmp_path = SPEND_REPORT_PATH + ".tmp"
+    with open(tmp_path, "w") as f:
         json.dump(summary, f, indent=2, sort_keys=True)
         f.write("\n")
+    os.replace(tmp_path, SPEND_REPORT_PATH)
+
+
+def _poll_and_persist(key_requests: dict[str, dict], start_date: str) -> None:
+    """One poll cycle: collect the spend summary and persist it.
+
+    Shared by the polling loop and the shutdown path so the final flush
+    exercises exactly the same code as every poll.
+    """
+    summary = collect_spend_summary(key_requests, start_date=start_date)
+    write_spend_summary(summary)
 
 
 def main():
@@ -162,11 +259,20 @@ def main():
     with open(READY_FILE_PATH, "w") as f:
         f.write("ready\n")
 
-    # Poll LiteLLM spend and keep writing a host-recoverable summary file.
+    # Fixed window start so token queries capture the entire run.
+    # End date is refreshed every poll inside collect_spend_summary.
+    run_start_date = _today_str()
+
+    # Poll LiteLLM spend and tokens, keep writing host-recoverable summary.
     while not _SHUTDOWN:
-        summary = collect_spend_summary(key_requests)
-        write_spend_summary(summary)
+        _poll_and_persist(key_requests, run_start_date)
         time.sleep(max(SPEND_POLL_INTERVAL_SEC, 1))
+
+    # Final flush: capture traffic from the last partial interval
+    try:
+        _poll_and_persist(key_requests, run_start_date)
+    except Exception as e:
+        print(f"Error in final spend flush: {e}")
 
     return 0
 

--- a/oss-crs-infra/webui-publisher/main.py
+++ b/oss-crs-infra/webui-publisher/main.py
@@ -46,9 +46,7 @@ PROCESSED_EXCHANGE_TYPES = tuple(
 )
 COVERAGE_BUILD_DIR = Path("/coverage_build")
 LOG_DIR = Path("/webui_logs")
-# LiteLLM spend report (mounted read-only when an LLM proxy is in the run).
-# Written periodically by the litellm-key-gen sidecar; absent for LLM-free runs.
-SPEND_REPORT_PATH = Path("/litellm-spend-report.json")
+SPEND_REPORT_PATH = Path("/spend/litellm-spend-report.json")
 
 POLL_INTERVAL = 5  # seconds
 COVERAGE_INTERVAL = 30  # seconds
@@ -94,27 +92,52 @@ def _scan_dir(root: Path) -> dict[str, int]:
     return counts
 
 
-def read_cost() -> dict | None:
-    """Read LLM spend from the litellm-key-gen spend report, if present.
+def read_cost(report_path: Path | None = None) -> dict | None:
+    """Read LLM spend and token counts from the litellm-key-gen report.
 
-    Returns ``{"total": float, "per_crs": {crs_name: float}}`` or ``None`` when
-    no spend report exists yet (e.g. LLM-free runs or before the first write).
+    Returns ``{"total": float, "per_crs": {...}, "prompt_tokens": int,
+    "completion_tokens": int,
+    "per_crs_tokens": {crs_name: {...}}}`` or ``None`` when no spend report
+    exists yet (e.g. LLM-free runs or before the first write). Token fields
+    default to 0 for old reports that predate token tracking; totals are
+    prompt + completion summed by the reader.
     """
-    if not SPEND_REPORT_PATH.is_file():
+    path = report_path if report_path is not None else SPEND_REPORT_PATH
+    if not path.is_file():
         return None
     try:
-        data = json.loads(SPEND_REPORT_PATH.read_text())
+        data = json.loads(path.read_text())
     except (OSError, json.JSONDecodeError):
         return None
-    total = data.get("totals", {}).get("credits_used")
-    per_crs = {
-        name: entry.get("credits_used", 0.0)
-        for name, entry in data.get("crs", {}).items()
-        if isinstance(entry, dict)
-    }
+    totals_raw = data.get("totals", {})
+    totals = totals_raw if isinstance(totals_raw, dict) else {}
+    crs_raw = data.get("crs", {})
+    crs = crs_raw if isinstance(crs_raw, dict) else {}
+    total = totals.get("credits_used")
+    entries = {name: entry for name, entry in crs.items() if isinstance(entry, dict)}
+    per_crs = {name: entry.get("credits_used", 0.0) for name, entry in entries.items()}
     if total is None and not per_crs:
         return None
-    return {"total": total, "per_crs": per_crs}
+    prompt = sum(entry.get("prompt_tokens", 0) for entry in entries.values())
+    completion = sum(entry.get("completion_tokens", 0) for entry in entries.values())
+    # Prefer the report's totals when present (old reports lack token fields).
+    totals_tokens = {
+        "prompt_tokens": totals.get("prompt_tokens", 0) or prompt,
+        "completion_tokens": totals.get("completion_tokens", 0) or completion,
+    }
+    per_crs_tokens = {
+        name: {
+            "prompt_tokens": entry.get("prompt_tokens", 0),
+            "completion_tokens": entry.get("completion_tokens", 0),
+        }
+        for name, entry in entries.items()
+    }
+    return {
+        "total": total,
+        "per_crs": per_crs,
+        **totals_tokens,
+        "per_crs_tokens": per_crs_tokens,
+    }
 
 
 def build_snapshot() -> dict:

--- a/oss_crs/src/config/artifacts.py
+++ b/oss_crs/src/config/artifacts.py
@@ -75,6 +75,8 @@ class MetaArtifactCounts(BaseModel):
 
 class MetaLLMStats(BaseModel):
     credits_used: float = 0.0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
 
 
 class MetaSidecarStats(BaseModel):

--- a/oss_crs/src/crs_compose.py
+++ b/oss_crs/src/crs_compose.py
@@ -2156,11 +2156,19 @@ class CRSCompose:
         crs_raw = raw.get("crs")
         crs = crs_raw if isinstance(crs_raw, dict) else {}
         return {
-            "totals": {"credits_used": float(totals.get("credits_used", 0.0) or 0.0)},
+            "totals": {
+                "credits_used": totals.get("credits_used", 0.0),
+                "prompt_tokens": totals.get("prompt_tokens", 0),
+                "completion_tokens": totals.get("completion_tokens", 0),
+            },
             "crs": {
-                name: {"credits_used": float((entry or {}).get("credits_used", 0.0))}
+                name: {
+                    "credits_used": entry.get("credits_used", 0.0),
+                    "prompt_tokens": entry.get("prompt_tokens", 0),
+                    "completion_tokens": entry.get("completion_tokens", 0),
+                }
                 for name, entry in crs.items()
-                if isinstance(name, str)
+                if isinstance(name, str) and isinstance(entry, dict)
             },
         }
 
@@ -2207,7 +2215,11 @@ class CRSCompose:
             "artifacts": {
                 name.replace("-", "_"): 0 for name in SUBMITTED_ARTIFACT_DIR_NAMES
             },
-            "llm": {"credits_used": 0.0},
+            "llm": {
+                "credits_used": 0.0,
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+            },
             "sidecar": {
                 "patch_builds": 0,
                 "patch_tests": 0,
@@ -2223,12 +2235,11 @@ class CRSCompose:
             sidecar = self._read_sidecar_counts_for_crs(
                 crs.name, target, run_id, sanitizer
             )
+            crs_llm = llm_summary.get("crs", {}).get(crs.name, {})
             llm = {
-                "credits_used": float(
-                    llm_summary.get("crs", {})
-                    .get(crs.name, {})
-                    .get("credits_used", 0.0)
-                )
+                "credits_used": crs_llm.get("credits_used", 0.0),
+                "prompt_tokens": crs_llm.get("prompt_tokens", 0),
+                "completion_tokens": crs_llm.get("completion_tokens", 0),
             }
 
             crs_meta[crs.name] = {
@@ -2241,6 +2252,8 @@ class CRSCompose:
                 totals["artifacts"][key] += artifacts.get(key, 0)
             for key in totals["sidecar"]:
                 totals["sidecar"][key] += sidecar.get(key, 0)
+            for key in ("prompt_tokens", "completion_tokens"):
+                totals["llm"][key] += llm.get(key, 0)
 
         llm_total = float(llm_summary.get("totals", {}).get("credits_used", 0.0))
         if llm_total == 0.0:
@@ -2248,6 +2261,12 @@ class CRSCompose:
                 sum(crs_meta[name]["llm"]["credits_used"] for name in crs_meta), 6
             )
         totals["llm"]["credits_used"] = llm_total
+        # Prefer the report's totals when present (old reports lack tokens and
+        # read as 0); fall back to the per-CRS sum.
+        file_tokens = llm_summary.get("totals", {})
+        for key in ("prompt_tokens", "completion_tokens"):
+            if file_tokens.get(key):
+                totals["llm"][key] = file_tokens[key]
 
         return {
             "totals": totals,

--- a/oss_crs/src/templates/renderer.py
+++ b/oss_crs/src/templates/renderer.py
@@ -367,6 +367,8 @@ def render_run_crs_compose_docker_compose(
         tmp_dir = tmp_docker_compose.dir if tmp_docker_compose.dir else Path("/tmp")
         litellm_spend_report_path = str(tmp_dir / "litellm-spend-report.json")
 
+    litellm_spend_report_dir = str(Path(litellm_spend_report_path).parent)
+
     context = {
         "libCRS_path": str(LIBCRS_PATH),
         "crs_compose_name": crs_compose_name,
@@ -413,7 +415,7 @@ def render_run_crs_compose_docker_compose(
         "litellm_image": OSS_CRS_LITELLM_TAG,
         "litellm_internal_url": LITELLM_INTERNAL_URL,
         "offline": crs_compose.offline,
-        "litellm_spend_report_path": litellm_spend_report_path,
+        "litellm_spend_report_dir": litellm_spend_report_dir,
         "postgres_image": OSS_CRS_POSTGRES_TAG,
         "postgres_user": POSTGRES_USER,
         "postgres_port": POSTGRES_PORT,

--- a/oss_crs/src/templates/run-crs-compose.docker-compose.yaml.j2
+++ b/oss_crs/src/templates/run-crs-compose.docker-compose.yaml.j2
@@ -150,7 +150,7 @@ services:
         condition: service_healthy
     environment:
       - LITELLM_API_URL={{ litellm_internal_url }}
-      - LITELLM_SPEND_REPORT_PATH=/litellm-spend-report.json
+      - LITELLM_SPEND_REPORT_PATH=/spend/litellm-spend-report.json
       - LITELLM_SPEND_POLL_INTERVAL_SEC=5
     secrets:
       - litellm_master_key
@@ -164,7 +164,7 @@ services:
       {{ crs_compose_name }}-network:
     volumes:
       - {{ llm_context.key_gen_request_path }}:/key_gen_request.yaml:ro
-      - {{ litellm_spend_report_path }}:/litellm-spend-report.json:rw
+      - {{ litellm_spend_report_dir }}:/spend:rw
   ###########################################
 {% endif %}
   ###########################################
@@ -270,7 +270,7 @@ services:
       - {{ webui_log_dir }}:/webui_logs:rw
       - {{ work_dir.get_build_output_dir("oss-crs-coverage", target, build_id, sanitizer) }}:/coverage_build:ro
 {%- if llm_context is defined and llm_context.mode == "internal" %}
-      - {{ litellm_spend_report_path }}:/litellm-spend-report.json:ro
+      - {{ litellm_spend_report_dir }}:/spend:ro
 {%- endif %}
     networks:
       {{ crs_compose_name }}-infra-only-network:

--- a/oss_crs/src/webui.py
+++ b/oss_crs/src/webui.py
@@ -287,11 +287,22 @@ def publish_final_snapshot(
         cost = None
         if spend_path.exists() and spend_path.stat().st_size > 0:
             spend = compose._read_litellm_spend_summary(run_id, sanitizer)
+            totals = spend.get("totals", {})
+            per_crs = spend.get("crs", {})
             cost = {
-                "total": spend.get("totals", {}).get("credits_used"),
+                "total": totals.get("credits_used"),
                 "per_crs": {
                     name: entry.get("credits_used", 0.0)
-                    for name, entry in spend.get("crs", {}).items()
+                    for name, entry in per_crs.items()
+                },
+                "prompt_tokens": totals.get("prompt_tokens", 0),
+                "completion_tokens": totals.get("completion_tokens", 0),
+                "per_crs_tokens": {
+                    name: {
+                        "prompt_tokens": entry.get("prompt_tokens", 0),
+                        "completion_tokens": entry.get("completion_tokens", 0),
+                    }
+                    for name, entry in per_crs.items()
                 },
             }
 

--- a/oss_crs/tests/unit/test_cli_artifacts_prerun.py
+++ b/oss_crs/tests/unit/test_cli_artifacts_prerun.py
@@ -12,6 +12,7 @@ from oss_crs.src.cli.artifacts import (
     handle_artifacts,
     resolve_run_context,
 )
+from oss_crs.src.crs_compose import CRSCompose
 from oss_crs.src.cli.crs_compose import add_artifacts_command, add_archive_command
 from oss_crs.src.utils import normalize_run_id
 
@@ -182,6 +183,15 @@ class _FakeWorkDir:
             self.get_log_dir(crs_name, target, run_id, sanitizer)
             / "libcrs-sidecar-metrics.jsonl"
         )
+
+    def get_litellm_spend_report_file(
+        self, run_id: str, sanitizer: str, *, create_parent: bool = False
+    ):
+        _ = create_parent
+        return self._tmp / sanitizer / "runs" / run_id / "litellm-spend-report.json"
+
+    def get_submit_artifact_counts(self, crs_name, target, run_id, sanitizer):
+        return {}
 
 
 def _make_compose(
@@ -518,3 +528,88 @@ def test_archive_target_harness_is_optional():
         ]
     )
     assert args.target_harness is None
+
+
+def _make_meta_compose(tmp_path, run_id: str):
+    """A _make_compose namespace with the real spend/sidecar reader methods
+    bound, so _collect_run_meta runs its production code path."""
+    compose = _make_compose(tmp_path, resolved_run_id=run_id)
+    compose._read_json_file = CRSCompose._read_json_file
+    compose._read_litellm_spend_summary = (
+        CRSCompose._read_litellm_spend_summary.__get__(compose)
+    )
+    compose._read_sidecar_counts_for_crs = (
+        CRSCompose._read_sidecar_counts_for_crs.__get__(compose)
+    )
+    return compose
+
+
+def test_collect_run_meta_carries_token_counts(tmp_path) -> None:
+    run_id = "token-run-id"
+    sanitizer = "address"
+    report = tmp_path / sanitizer / "runs" / run_id / "litellm-spend-report.json"
+    report.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text(
+        json.dumps(
+            {
+                "totals": {
+                    "credits_used": 3.0,
+                    "prompt_tokens": 300,
+                    "completion_tokens": 150,
+                },
+                "crs": {
+                    "crs-a": {
+                        "credits_used": 1.0,
+                        "prompt_tokens": 100,
+                        "completion_tokens": 50,
+                    },
+                    "crs-b": {
+                        "credits_used": 2.0,
+                        "prompt_tokens": 200,
+                        "completion_tokens": 100,
+                    },
+                },
+            }
+        )
+    )
+
+    compose = _make_meta_compose(tmp_path, run_id)
+    target = _FakeTarget("fuzz_target")
+    meta = CRSCompose._collect_run_meta(compose, target, run_id, sanitizer)
+    assert meta["crs"]["crs-a"]["llm"] == {
+        "credits_used": 1.0,
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+    }
+    assert meta["totals"]["llm"] == {
+        "credits_used": 3.0,
+        "prompt_tokens": 300,
+        "completion_tokens": 150,
+    }
+
+
+def test_collect_run_meta_sums_tokens_when_totals_missing(tmp_path) -> None:
+    run_id = "token-sum-run-id"
+    sanitizer = "address"
+    report = tmp_path / sanitizer / "runs" / run_id / "litellm-spend-report.json"
+    report.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text(
+        json.dumps(
+            {
+                "totals": {"credits_used": 1.0},
+                "crs": {
+                    "crs-a": {
+                        "credits_used": 1.0,
+                        "prompt_tokens": 100,
+                        "completion_tokens": 50,
+                    }
+                },
+            }
+        )
+    )
+
+    compose = _make_meta_compose(tmp_path, run_id)
+    target = _FakeTarget("fuzz_target")
+    meta = CRSCompose._collect_run_meta(compose, target, run_id, sanitizer)
+    assert meta["totals"]["llm"]["prompt_tokens"] == 100
+    assert meta["totals"]["llm"]["completion_tokens"] == 50

--- a/oss_crs/tests/unit/test_litellm_key_gen.py
+++ b/oss_crs/tests/unit/test_litellm_key_gen.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: MIT
+"""Tests for the litellm-key-gen spend/token orchestration.
+
+The sidecar is a standalone image, so it is loaded from its file path with
+the master-key secret stubbed (only during import). HTTP is mocked; date
+handling is asserted against the real clock.
+"""
+
+import hashlib
+import importlib.util
+import json
+from datetime import date, timedelta
+from pathlib import Path
+from types import ModuleType
+from unittest import mock
+
+import pytest
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+KEYGEN_DIR = REPO_ROOT / "oss-crs-infra" / "litellm-key-gen"
+
+
+@pytest.fixture(scope="module")
+def keygen() -> ModuleType:
+    with mock.patch("builtins.open", mock.mock_open(read_data="test-master")):
+        spec = importlib.util.spec_from_file_location(
+            "litellm_key_gen_main", KEYGEN_DIR / "main.py"
+        )
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    yield module
+
+
+def _spend_response(spend: float) -> mock.MagicMock:
+    response = mock.MagicMock()
+    response.json.return_value = {"info": {"spend": spend}}
+    response.raise_for_status.return_value = None
+    return response
+
+
+def _logs_response(rows: object) -> mock.MagicMock:
+    response = mock.MagicMock()
+    response.json.return_value = rows
+    response.raise_for_status.return_value = None
+    return response
+
+
+def test_collect_spend_summary_aggregates_tokens(keygen: ModuleType) -> None:
+    with (
+        mock.patch.object(keygen, "get_key_spend", return_value=1.5),
+        mock.patch.object(keygen, "get_key_tokens", return_value=(100, 50)),
+    ):
+        summary = keygen.collect_spend_summary(
+            {"a": {"api_key": "k1"}, "b": {"api_key": ""}}
+        )
+    assert summary["totals"] == {
+        "credits_used": 1.5,
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+    }
+    assert summary["crs"]["a"] == {
+        "credits_used": 1.5,
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+    }
+    assert summary["crs"]["b"]["prompt_tokens"] == 0
+    assert "updated_at" in summary
+
+
+def test_collect_uses_exclusive_end_date(keygen: ModuleType) -> None:
+    """Regression test: LiteLLM treats end_date as exclusive, so querying
+    with end == start == today returns zero rows. The collector must roll
+    the end forward to tomorrow when the caller omits it."""
+    seen: dict = {}
+
+    def fake_get(url: str, **kwargs: object) -> mock.MagicMock:
+        params = kwargs.get("params")
+        assert isinstance(params, dict)
+        if url.endswith("/spend/logs"):
+            seen.update(params)
+            return _logs_response([])
+        return _spend_response(0.0)
+
+    with mock.patch.object(keygen.requests, "get", side_effect=fake_get):
+        keygen.collect_spend_summary({"a": {"api_key": "k1"}}, start_date="2026-09-04")
+    assert seen["start_date"] == "2026-09-04"
+    assert seen["end_date"] == (date.today() + timedelta(days=1)).isoformat()
+    assert seen["end_date"] > seen["start_date"]
+
+
+def test_get_key_tokens_fail_open(keygen: ModuleType) -> None:
+    with mock.patch.object(
+        keygen.requests,
+        "get",
+        side_effect=requests.exceptions.ConnectionError("down"),
+    ):
+        assert keygen.get_key_tokens("k1") == (0, 0)
+        assert keygen.get_key_spend("k1") == 0.0
+    assert keygen.get_key_tokens("") == (0, 0)
+
+
+def test_collect_matches_spend_logs_end_to_end(
+    keygen: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Full loop against the live v1.94.0 shapes: /key/info spend plus
+    /spend/logs rows filtered by key hash, written to the report file."""
+    raw = "sk-live-key"
+    key_hash = hashlib.sha256(raw.encode()).hexdigest()
+    rows = [
+        {"api_key": key_hash, "prompt_tokens": 30055, "completion_tokens": 2650},
+        {"api_key": key_hash, "prompt_tokens": 21693, "completion_tokens": 19},
+        {"api_key": "other", "prompt_tokens": 99999, "completion_tokens": 99999},
+    ]
+
+    def fake_get(url: str, **kwargs: object) -> mock.MagicMock:
+        if url.endswith("/key/info"):
+            return _spend_response(2.0)
+        return _logs_response(rows)
+
+    report = tmp_path / "spend.json"
+    monkeypatch.setattr(keygen, "SPEND_REPORT_PATH", str(report))
+    with mock.patch.object(keygen.requests, "get", side_effect=fake_get):
+        summary = keygen.collect_spend_summary(
+            {"crs-a": {"api_key": raw}}, start_date="2026-09-04"
+        )
+        keygen.write_spend_summary(summary)
+    on_disk = json.loads(report.read_text())
+    assert on_disk["crs"]["crs-a"] == {
+        "credits_used": 2.0,
+        "prompt_tokens": 51748,
+        "completion_tokens": 2669,
+    }
+    assert on_disk["totals"]["prompt_tokens"] == 51748
+    assert on_disk["totals"]["completion_tokens"] == 2669
+
+
+def test_poll_and_persist_delegates(keygen: ModuleType) -> None:
+    with (
+        mock.patch.object(
+            keygen, "collect_spend_summary", return_value={"ok": True}
+        ) as collect,
+        mock.patch.object(keygen, "write_spend_summary") as write,
+    ):
+        keygen._poll_and_persist({"a": {"api_key": "k"}}, "2026-09-04")
+    collect.assert_called_once_with({"a": {"api_key": "k"}}, start_date="2026-09-04")
+    write.assert_called_once_with({"ok": True})
+
+
+def test_write_spend_summary_is_atomic(
+    keygen: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The report file must never be left truncated: payload goes to a temp
+    file first, then moves into place."""
+    report = tmp_path / "spend.json"
+    monkeypatch.setattr(keygen, "SPEND_REPORT_PATH", str(report))
+    keygen.write_spend_summary({"totals": {"credits_used": 1.0}})
+    assert json.loads(report.read_text()) == {"totals": {"credits_used": 1.0}}
+    assert not Path(str(report) + ".tmp").exists()
+
+
+def test_main_flushes_on_shutdown(keygen: ModuleType) -> None:
+    """A forced final poll runs when the loop exits via shutdown, so the
+    report is not stuck a poll interval behind at teardown."""
+    keygen._SHUTDOWN = True
+    try:
+        request_yaml = "{crs-a: {api_key: k, required_llms: [], llm_budget: 1}}\n"
+        with (
+            mock.patch("builtins.open", mock.mock_open(read_data=request_yaml)),
+            mock.patch.object(keygen, "get_available_models", return_value=[]),
+            mock.patch.object(keygen, "create_llm_key", return_value="k"),
+            mock.patch.object(
+                keygen, "collect_spend_summary", return_value={"totals": {}}
+            ) as collect,
+        ):
+            assert keygen.main() == 0
+    finally:
+        keygen._SHUTDOWN = False
+    collect.assert_called_once()

--- a/oss_crs/tests/unit/test_template_rendering.py
+++ b/oss_crs/tests/unit/test_template_rendering.py
@@ -276,12 +276,80 @@ class TestMountInfrastructure:
             "postgres_port": 5432,
             "postgres_host": "postgres.oss-crs-infra-only",
             "litellm_internal_url": "http://litellm.oss-crs:4000",
-            "litellm_spend_report_path": "/spend/litellm-spend-report.json",
+            "litellm_spend_report_dir": "/spend",
             "sidecar_env": {},
         }
         rendered = template.render(context)
 
         assert "image: oss-crs-litellm-key-gen:latest" in rendered
+
+    def test_spend_report_uses_parent_dir_mounts(self, jinja_env):
+        """Spend report is shared as a parent-dir mount, never a file mount.
+
+        The key-gen sidecar writes the report with atomic os.replace, which
+        fails with EBUSY on a bind-mounted file; a file mount on the
+        publisher side would likewise pin a stale inode across swaps.
+        """
+        from types import SimpleNamespace
+
+        template = jinja_env.get_template("run-crs-compose.docker-compose.yaml.j2")
+        llm_context = SimpleNamespace(
+            mode="internal",
+            litellm_env_secret_files={},
+            litellm_config_path="/cfg/litellm.yaml",
+            key_gen_request_path="/req/key_gen_request.yaml",
+            secret_files={},
+            master_key_file="/secrets/master_key",
+            postgres_password_file="/secrets/pg_password",
+        )
+        context = {
+            "libCRS_path": "/libcrs",
+            "crs_compose_name": "crs_compose_run123",
+            "crs_list": [],
+            "crs_compose_env": {"type": "local"},
+            "target_env": {},
+            "target": _MockTarget(proj_path="/home/user/myproject", has_repo=False),
+            "work_dir": _MockWorkDir(),
+            "run_id": "run-123",
+            "build_id": "build-123",
+            "sanitizer": "address",
+            "oss_crs_infra_root_path": "/oss-crs-infra",
+            "infra_sidecar_images": {},
+            "snapshot_image_tag": "",
+            "resolve_dockerfile": lambda c, d: str(c) + "/" + str(d),
+            "run_module_image": lambda n, m, mc: f"oss-crs-runner:{n}-{m}",
+            "fetch_dir": "",
+            "exchange_dir": "",
+            "fetch_dir_mounts": {},
+            "processed_exchange_dir": None,
+            "bug_finding_ensemble": False,
+            "bug_fix_ensemble": False,
+            "cgroup_parents": None,
+            "module_envs": {},
+            "fuzz_proj_path": "/home/user/myproject",
+            "target_source_path": "/extracted/source",
+            "llm_context": llm_context,
+            "litellm_image": "litellm@sha256:abc",
+            "postgres_image": "postgres@sha256:def",
+            "postgres_user": "crs",
+            "postgres_port": 5432,
+            "postgres_host": "postgres.oss-crs-infra-only",
+            "litellm_internal_url": "http://litellm.oss-crs:4000",
+            "litellm_spend_report_dir": "/host/runs/run-123",
+            "sidecar_env": {},
+            "web_ui": True,
+            "webui_url": "http://webui.example.com",
+            "webui_uid": 1000,
+            "webui_gid": 1000,
+            "webui_log_dir": "/host/webui-logs",
+            "crs_resources": {},
+        }
+        rendered = template.render(context)
+
+        assert "LITELLM_SPEND_REPORT_PATH=/spend/litellm-spend-report.json" in rendered
+        assert "/host/runs/run-123:/spend:rw" in rendered
+        assert "/host/runs/run-123:/spend:ro" in rendered
+        assert ":/litellm-spend-report.json:" not in rendered
 
     def test_target_source_mount_always_present(self, jinja_env):
         """target_source_path volume mount should always appear unconditionally."""

--- a/oss_crs/tests/unit/test_webui_publisher.py
+++ b/oss_crs/tests/unit/test_webui_publisher.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: MIT
+"""Tests for the webui-publisher spend-report reader.
+
+The publisher is a standalone sidecar image, so it is loaded from its file
+path rather than imported as a package.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PUB_DIR = REPO_ROOT / "oss-crs-infra" / "webui-publisher"
+
+
+@pytest.fixture()
+def publisher() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "webui_publisher_main", PUB_DIR / "main.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    yield module
+
+
+def _write_report(path: Path, payload: object) -> Path:
+    path.write_text(json.dumps(payload))
+    return path
+
+
+def test_read_cost_new_schema(publisher: ModuleType, tmp_path: Path) -> None:
+    report = _write_report(
+        tmp_path / "spend.json",
+        {
+            "totals": {
+                "credits_used": 1.5,
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+            },
+            "crs": {
+                "crs-a": {
+                    "credits_used": 1.5,
+                    "prompt_tokens": 100,
+                    "completion_tokens": 50,
+                }
+            },
+        },
+    )
+    cost = publisher.read_cost(report)
+    assert cost is not None
+    assert cost["total"] == 1.5
+    assert cost["per_crs"] == {"crs-a": 1.5}
+    assert cost["prompt_tokens"] == 100
+    assert cost["completion_tokens"] == 50
+    assert "total_tokens" not in cost
+    assert cost["per_crs_tokens"] == {
+        "crs-a": {"prompt_tokens": 100, "completion_tokens": 50}
+    }
+
+
+def test_read_cost_old_schema_defaults_tokens(
+    publisher: ModuleType, tmp_path: Path
+) -> None:
+    report = _write_report(
+        tmp_path / "spend.json",
+        {"totals": {"credits_used": 2.0}, "crs": {"a": {"credits_used": 2.0}}},
+    )
+    cost = publisher.read_cost(report)
+    assert cost is not None
+    assert cost["total"] == 2.0
+    assert cost["prompt_tokens"] == 0
+    assert cost["completion_tokens"] == 0
+    assert cost["per_crs_tokens"] == {"a": {"prompt_tokens": 0, "completion_tokens": 0}}
+
+
+def test_read_cost_sums_totals_when_missing(
+    publisher: ModuleType, tmp_path: Path
+) -> None:
+    report = _write_report(
+        tmp_path / "spend.json",
+        {
+            "totals": {"credits_used": 3.0},
+            "crs": {
+                "a": {
+                    "credits_used": 1.0,
+                    "prompt_tokens": 10,
+                    "completion_tokens": 4,
+                },
+                "b": {
+                    "credits_used": 2.0,
+                    "prompt_tokens": 20,
+                    "completion_tokens": 6,
+                },
+            },
+        },
+    )
+    cost = publisher.read_cost(report)
+    assert cost is not None
+    assert cost["prompt_tokens"] == 30
+    assert cost["completion_tokens"] == 10
+    assert cost["prompt_tokens"] + cost["completion_tokens"] == 40
+
+
+def test_read_cost_missing_or_corrupt(publisher: ModuleType, tmp_path: Path) -> None:
+    assert publisher.read_cost(tmp_path / "absent.json") is None
+    corrupt = tmp_path / "corrupt.json"
+    corrupt.write_text("{not json")
+    assert publisher.read_cost(corrupt) is None
+    # Default path (/spend/litellm-spend-report.json) is absent outside containers.
+    assert publisher.read_cost() is None


### PR DESCRIPTION
## Summary

Describe what changed and why.

Added the fields completion_tokens (output tokens) and prompt_tokens (input tokens) in the log files litellm-spend-report.json and meta.json to support cost estimation even when the model costs are unknown (e.g. for local models). The token counts are determined by polling LiteLLM and only work in internal mode.

## User Impact

- [X] User-facing change
- [ ] Internal-only change

If user-facing, describe CLI/API/config/docs impact and migration steps.

No migration steps needed, if token counts are not present in LiteLLM they will be set to 0 by default.

## Release Note / Changelog

- [X] I updated `CHANGELOG.md` (`[Unreleased]`) for user-facing changes
- [ ] No changelog entry needed (internal-only refactor/test/chore)

If this PR includes deprecation or breaking behavior, include:
- replacement path for users
- planned removal version/release window

## Validation

List tests/checks run and their results.

All tests were run and passed successfully.

## Checklist

- [X] I followed Conventional Commits
- [X] I updated docs for behavior/config/CLI changes
- [X] I added/updated tests for behavior changes
- [X] I considered backward compatibility and migration impact
