### PR TITLE
Add support for running user-defined MCP servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ stricter subset of Keep a Changelog).
 - `--offline` flag for all subcommands: disables git fetch
 - `oss-crs build-target` now validates `--bug-candidate`/`--bug-candidate-dir` the same way `oss-crs run` does: a missing path, or a directory passed to `--bug-candidate` (or a file passed to `--bug-candidate-dir`), fails before any container starts instead of being silently ignored.
 - `libCRS` `apply_patch_build`: builder-side errors returned before a `rebuild_id` is assigned are now written to `<response_dir>/stderr.log` instead of being dropped. The public signature (`apply_patch_build(patch_path, response_dir, ...)`) and the positional shell form (`apply-patch-build <patch> <response_dir>`) are unchanged; `apply_patch_test` and `run-pov` are likewise unchanged.
+- Added support for user-defined MCP servers
+- `libCRS mcp list|describe|call` — discover, inspect, and invoke LiteLLM MCP gateway tools
 
 ### Added
 - `oss-crs list-harnesses --fuzz-proj-path <PATH_TO_PROJ>` — builds an OSS-Fuzz project through its default Docker compile path and lists its runnable fuzz harnesses, reusing cached build artifacts until the project inputs or repository HEAD change.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ For a quick introduction and setup instructions, see the [project README](../REA
 | [CRS (`crs.yaml`)](config/crs.md) | Per-CRS config — prepare, build, and run phases for a single CRS |
 | [Target Project (`project.yaml`)](config/target-project.md) | Target project setup — OSS-Fuzz format and `project.yaml` schema |
 | [LLM (`litellm_config.yaml`)](config/llm.md) | LiteLLM config file format for internal mode (provider routing, API keys, custom endpoints) |
+| [MCP servers](config/mcp.md) | Configuration of user-defined MCP servers |
 
 ## Architecture & Design
 

--- a/docs/config/crs-compose.md
+++ b/docs/config/crs-compose.md
@@ -32,6 +32,8 @@ llm_config:                    # optional
       url_env: <host-env-var-name>
       key: <external-litellm-api-key>         # oneof(key, key_env)
       key_env: <host-env-var-name>
+mcp_servers:                     # optional; requires internal LLM mode
+  - <mcp-server-name>            # see docs/config/mcp.md
 <crs-name>:
   cpuset: <cpu-set>
   memory: <memory-limit>
@@ -95,6 +97,19 @@ llm_config:
     external:
       url_env: LITELLM_URL
       key_env: LITELLM_API_KEY
+```
+
+---
+
+### `mcp_servers` (optional)
+
+List of MCP server names (from `registry/mcp/`) to run as sidecars and
+expose to agents via the LiteLLM gateway and the `libCRS mcp` CLI. Requires
+internal LLM mode. See [MCP servers](mcp.md).
+
+```yaml
+mcp_servers:
+  - ast_grep
 ```
 
 ---

--- a/docs/config/mcp.md
+++ b/docs/config/mcp.md
@@ -1,0 +1,50 @@
+# MCP Servers
+
+OSS-CRS can run [Model Context Protocol](https://modelcontextprotocol.io/)
+servers and expose their tools to agents through the
+internal LiteLLM proxy. Agents call tools via the `libCRS mcp` CLI, so no
+agent harness needs its own MCP client. Requires internal LLM mode.
+
+## Registry (`registry/mcp/*.yaml`)
+
+| Field             | Required | Default | Description                                       |
+| ----------------- | -------- | ------- | ------------------------------------------------- |
+| `name`            | Yes      | —       | Alphanumeric plus `_`. Used as the container alias and gateway key. |
+| `image`           | Yes      | —       | Path to dockerfile or docker image url.           |
+| `url`             | Yes      | —       | `Address of MCP server (e.g. http://name:port/mcp)` |
+| `requires_source` | No       | `false` | Mount target source read-only at `/OSS_CRS_TARGET_SOURCE`. |
+| `command`         | No       | image default | Override default command of MCP server image |
+
+## Compose usage
+
+```yaml
+mcp_servers:
+  - ast_grep
+```
+
+Each entry renders a `mcp-<name>` service on the infra-only network.
+
+## LiteLLM gateway
+
+Each server is registered with `transport: http` and `allow_all_keys: true`.
+Tools execute via the REST surface:
+
+- `GET /mcp-rest/tools/list` — tools visible to the caller's key.
+- `POST /mcp-rest/tools/call` — body `{"server_id": ..., "name": ...,
+  "arguments": {...}}`; `server_id` accepts a UUID, name, or alias.
+
+## Prompt hook
+
+Registering any server wires a LiteLLM callback that appends a short
+`libCRS mcp` usage note to every request's system prompt. The note is
+skipped when already present, and an error leaves the request unchanged.
+
+## `libCRS mcp` CLI
+
+Used by the agent to access MCP servers. Full command reference with examples: [libCRS CLI Reference](../design/libCRS.md#mcp-commands).
+
+## Adding a new MCP server
+
+1. Create a docker image with the MCP server HTTP API exposed to LiteLLM (listening
+on 0.0.0.0).
+2. Create a corresponding registry entry in registry/mcp/.

--- a/docs/design/libCRS.md
+++ b/docs/design/libCRS.md
@@ -555,6 +555,68 @@ $ libCRS apply-patch-test /tmp/fix.diff /tmp/test-result
 - `test.sh` is resolved by the builder sidecar (checked at `/src/run_tests.sh`, `/src/test.sh`, `$OSS_CRS_PROJ_PATH/test.sh`).
 - If no test script is found, the sidecar returns a skipped-success result (`retcode=0`) by contract.
 
+### MCP Commands
+
+#### `mcp list` ✅
+
+List MCP gateway tools available to this CRS.
+
+```bash
+$ libCRS mcp list [--server NAME] [--json]
+```
+
+| Argument | Description |
+|---|---|
+| `--server` | Only list tools from this MCP server (name, alias, or id) |
+| `--json` | Print the full tool list as JSON |
+
+**Example:**
+```bash
+$ libCRS mcp list
+```
+
+#### `mcp describe` ✅
+
+Show a tool's description and input schema.
+
+```bash
+$ libCRS mcp describe NAME [--server NAME] [--json]
+```
+
+| Argument | Description |
+|---|---|
+| `NAME` | Tool name |
+| `--server` | MCP server hint (name, alias, or id) |
+| `--json` | Print the full tool entry as JSON |
+
+**Example:**
+```bash
+$ libCRS mcp describe find_code
+```
+
+#### `mcp call` ✅
+
+Call an MCP tool and print its result.
+
+```bash
+$ libCRS mcp call NAME [--server NAME] [--args '<json>'] [--args-file PATH] [--timeout SEC] [--max-output-chars N] [--json]
+```
+
+| Argument | Description |
+|---|---|
+| `NAME` | Tool name |
+| `--server` | MCP server hint; only needed when the tool name is ambiguous across servers |
+| `--args` | Tool arguments as a JSON object string (default: `{}`) |
+| `--args-file` | Read tool arguments from a JSON file (overrides `--args`) |
+| `--timeout` | Request timeout in seconds |
+| `--max-output-chars` | Truncate printed output beyond this many characters (`0` disables; default: 20000) |
+| `--json` | Print the raw JSON result instead of extracted text |
+
+**Example:**
+```bash
+$ libCRS mcp call find_code --args '{"project_folder": "/src", "pattern": "malloc($size)"}'
+```
+
 ## Typical Usage in a CRS
 
 ### During Target Build Phase

--- a/libCRS/libCRS/cli/main.py
+++ b/libCRS/libCRS/cli/main.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MIT
+import json
 import os
 import sys
 import argparse
@@ -6,6 +7,7 @@ from pathlib import Path
 from ..base import DataType, SourceType, CRSUtils
 from ..local import LocalCRSUtils
 from ..common import get_run_env_type, EnvType
+from ..mcp import MCPClient, MCPGatewayError
 
 
 def init_crs_utils() -> CRSUtils:
@@ -66,8 +68,137 @@ def get_service_domain(crs_utils, args):
     print(domain)
 
 
+# =========================================================================
+# MCP gateway command handlers
+# =========================================================================
+
+_MCP_TRUNCATION_NOTE = (
+    "\n[libCRS mcp: output truncated at {limit} characters; "
+    "rerun with --max-output-chars 0 for the full output]"
+)
+
+
+def _mcp_client_from_env():
+    client = MCPClient.from_env()
+    if not client.is_enabled():
+        raise MCPGatewayError(
+            "MCP gateway is not configured in this environment "
+            "(OSS_CRS_LLM_API_URL and OSS_CRS_LLM_API_KEY_FILE / "
+            "OSS_CRS_LLM_API_KEY are missing)"
+        )
+    return client
+
+
+def _run_mcp(func, args):
+    try:
+        func(args)
+    except MCPGatewayError as e:
+        print(f"libCRS mcp: error: {e}", file=sys.stderr)
+        sys.exit(2)
+
+
+def _print_truncated(text: str, max_chars: int) -> None:
+    if max_chars and max_chars > 0 and len(text) > max_chars:
+        print(text[:max_chars] + _MCP_TRUNCATION_NOTE.format(limit=max_chars))
+    else:
+        print(text)
+
+
+def _mcp_list(args) -> None:
+    """`libCRS mcp list`: print available tool names (or full JSON)."""
+    client = _mcp_client_from_env()
+    tools = client.list_tools(getattr(args, "server", None))
+    if getattr(args, "json", False):
+        _print_truncated(
+            json.dumps(tools, indent=2), getattr(args, "max_output_chars", 20000) or 0
+        )
+        return
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        name = tool.get("name", "?")
+        desc = (tool.get("description") or "").splitlines()
+        print(f"{name} - {desc[0] if desc else ''}".rstrip(" -"))
+
+
+def _mcp_describe(args) -> None:
+    """`libCRS mcp describe`: print one tool's description + input schema."""
+    client = _mcp_client_from_env()
+    tool = client.describe(args.name, getattr(args, "server", None))
+    if getattr(args, "json", False):
+        print(json.dumps(tool, indent=2))
+        return
+    print(f"Tool: {tool.get('name', args.name)}")
+    info = tool.get("mcp_info") or {}
+    server = info.get("alias") or info.get("server_id") or "?"
+    print(f"Server: {server}")
+    if tool.get("description"):
+        print(f"Description: {tool['description']}")
+    print("Input schema:")
+    print(json.dumps(tool.get("inputSchema", {}), indent=2))
+
+
+def _mcp_call(args) -> None:
+    """`libCRS mcp call`: invoke a tool and print its result as text."""
+    if getattr(args, "args_file", None):
+        try:
+            arguments = json.loads(Path(args.args_file).read_text())
+        except (OSError, ValueError) as e:
+            print(f"libCRS mcp: error: cannot read --args-file: {e}", file=sys.stderr)
+            sys.exit(2)
+    else:
+        try:
+            arguments = json.loads(getattr(args, "args", "{}"))
+        except ValueError as e:
+            print(f"libCRS mcp: error: --args is not valid JSON: {e}", file=sys.stderr)
+            sys.exit(2)
+    if not isinstance(arguments, dict):
+        print(
+            "libCRS mcp: error: tool arguments must be a JSON object",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    client = _mcp_client_from_env()
+    result = client.call_tool(
+        args.name,
+        arguments,
+        getattr(args, "server", None),
+        timeout=getattr(args, "timeout", None),
+    )
+    if getattr(args, "json", False):
+        _print_truncated(
+            json.dumps(result, indent=2), getattr(args, "max_output_chars", 0) or 0
+        )
+        return
+    _print_truncated(
+        _extract_result_text(result), getattr(args, "max_output_chars", 20000) or 0
+    )
+
+
+def _extract_result_text(result) -> str:
+    """Best-effort text rendering of an MCP CallToolResult for agents."""
+    if isinstance(result, str):
+        return result
+    if not isinstance(result, dict):
+        return json.dumps(result, indent=2)
+    parts = []
+    for block in result.get("content", []) or []:
+        if not isinstance(block, dict):
+            parts.append(json.dumps(block))
+        elif block.get("type") == "text":
+            parts.append(str(block.get("text", "")))
+        else:
+            parts.append(json.dumps(block))
+    if parts:
+        return "\n".join(parts)
+    structured = result.get("structuredContent")
+    if structured is not None:
+        return json.dumps(structured, indent=2)
+    return json.dumps(result, indent=2)
+
+
 def main():
-    crs_utils = init_crs_utils()
     parser = argparse.ArgumentParser(
         prog="libCRS", description="libCRS - CRS utilities"
     )
@@ -522,14 +653,117 @@ def main():
         func=lambda args: get_service_domain(crs_utils, args)
     )
 
+    # =========================================================================
+    # MCP gateway commands (no CRS utils needed: the gateway is reached with
+    # the framework-injected LLM endpoint + per-CRS key)
+    # =========================================================================
+
+    mcp_parser = subparsers.add_parser(
+        "mcp",
+        help="Discover and call MCP tools via the OSS-CRS MCP gateway",
+    )
+    mcp_subparsers = mcp_parser.add_subparsers(
+        dest="mcp_command", help="MCP gateway operations"
+    )
+
+    mcp_list_parser = mcp_subparsers.add_parser(
+        "list", help="List MCP tools available to this CRS"
+    )
+    mcp_list_parser.add_argument(
+        "--server",
+        type=str,
+        default=None,
+        help="Only list tools from this MCP server (name, alias or id)",
+    )
+    mcp_list_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the full tool list as JSON",
+    )
+    mcp_list_parser.add_argument(
+        "--max-output-chars",
+        type=int,
+        default=20000,
+        help="Truncate printed output beyond this many characters "
+        "(0 disables truncation; default: 20000)",
+    )
+    mcp_list_parser.set_defaults(func=_mcp_list)
+
+    mcp_describe_parser = mcp_subparsers.add_parser(
+        "describe", help="Show a tool's description and input schema"
+    )
+    mcp_describe_parser.add_argument("name", help="Tool name")
+    mcp_describe_parser.add_argument(
+        "--server",
+        type=str,
+        default=None,
+        help="MCP server hint (name, alias or id)",
+    )
+    mcp_describe_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the full tool entry as JSON",
+    )
+    mcp_describe_parser.set_defaults(func=_mcp_describe)
+
+    mcp_call_parser = mcp_subparsers.add_parser(
+        "call", help="Call an MCP tool and print its result"
+    )
+    mcp_call_parser.add_argument("name", help="Tool name")
+    mcp_call_parser.add_argument(
+        "--server",
+        type=str,
+        default=None,
+        help="MCP server hint (name, alias or id)",
+    )
+    mcp_call_parser.add_argument(
+        "--args",
+        type=str,
+        default="{}",
+        help="Tool arguments as a JSON object string (default: {})",
+    )
+    mcp_call_parser.add_argument(
+        "--args-file",
+        type=Path,
+        default=None,
+        help="Read tool arguments from a JSON file (overrides --args)",
+    )
+    mcp_call_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=None,
+        help="Request timeout in seconds",
+    )
+    mcp_call_parser.add_argument(
+        "--max-output-chars",
+        type=int,
+        default=20000,
+        help="Truncate printed output beyond this many characters "
+        "(0 disables truncation; default: 20000)",
+    )
+    mcp_call_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the raw JSON result instead of extracted text",
+    )
+    mcp_call_parser.set_defaults(func=_mcp_call)
+
     args = parser.parse_args()
 
     if args.command is None:
         parser.print_help()
         return
 
-    else:
-        args.func(args)
+    if args.command == "mcp":
+        if getattr(args, "mcp_command", None) is None:
+            mcp_parser.print_help()
+            return
+        _run_mcp(args.func, args)
+        return
+
+    # All other commands need CRS utils (requires OSS_CRS_RUN_ENV_TYPE).
+    crs_utils = init_crs_utils()
+    args.func(args)
 
 
 if __name__ == "__main__":

--- a/libCRS/libCRS/mcp.py
+++ b/libCRS/libCRS/mcp.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: MIT
+"""Client for the OSS-CRS MCP gateway.
+
+The MCP gateway is the same LiteLLM proxy that fronts the LLM API: CRS
+containers reach it at ``OSS_CRS_LLM_API_URL`` with their per-CRS key (read
+from ``OSS_CRS_LLM_API_KEY_FILE``, falling back to ``OSS_CRS_LLM_API_KEY``).
+No CRS source changes are needed to use it -- the framework injects both the
+endpoint and the key, and this module discovers whatever MCP servers the
+framework registered.
+
+Discovery is two-level:
+
+- ``list_tools`` hits ``GET /mcp-rest/tools/list``. Each entry carries its
+  schema (``name``, ``description``, ``inputSchema``) plus ``mcp_info`` with
+  the owning server's ``server_id``/``alias``.
+- ``call_tool`` hits ``POST /mcp-rest/tools/call`` with ``server_id``,
+  ``name`` and ``arguments``. ``server_id`` accepts a UUID, server name or
+  alias; when omitted it is resolved from ``list_tools`` (the call fails if
+  the tool name is ambiguous across servers).
+
+Typical use from inside a CRS (or via the ``libCRS mcp`` CLI)::
+
+    from libCRS.mcp import MCPClient
+
+    client = MCPClient()
+    if client.is_enabled():
+        for tool in client.list_tools():
+            print(tool["name"], "-", tool.get("description", ""))
+        result = client.call_tool("semgrep_scan", {"code_files": [...]})
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import requests as http_requests
+
+logger = logging.getLogger(__name__)
+
+# Env vars injected by the framework (see oss_crs/src/env_policy.py). The key
+# file takes precedence: the framework mounts the per-CRS key as a secret file
+# and only sets the direct env var as a fallback.
+LLM_API_URL_ENV = "OSS_CRS_LLM_API_URL"
+LLM_API_KEY_ENV = "OSS_CRS_LLM_API_KEY"
+LLM_API_KEY_FILE_ENV = "OSS_CRS_LLM_API_KEY_FILE"
+
+# LiteLLM MCP REST endpoints (no LiteLLM source changes required).
+TOOLS_LIST_PATH = "/mcp-rest/tools/list"
+TOOLS_CALL_PATH = "/mcp-rest/tools/call"
+
+# Default request timeouts (seconds). Tool calls (e.g. scans) can take a
+# while, so the call timeout is generous; override per call as needed.
+LIST_TIMEOUT = 30
+CALL_TIMEOUT = 300
+
+
+class MCPGatewayError(RuntimeError):
+    """Raised when the MCP gateway is unconfigured or a request fails."""
+
+
+def _read_api_key(key: str | None = None, key_file: str | None = None) -> str:
+    """Resolve the per-CRS LiteLLM key, preferring the secret file."""
+    if key:
+        return key
+    key_file = (
+        key_file if key_file is not None else os.environ.get(LLM_API_KEY_FILE_ENV)
+    )
+    if key_file:
+        try:
+            return Path(key_file).read_text().strip()
+        except OSError as e:
+            raise MCPGatewayError(
+                f"Failed to read MCP gateway key file '{key_file}': {e}"
+            ) from e
+    return os.environ.get(LLM_API_KEY_ENV, "")
+
+
+class MCPClient:
+    """Thin client for the MCP gateway exposed to a CRS container.
+
+    The client is inert until used: it can always be instantiated (even when
+    the gateway is disabled and the env vars are absent), and :meth:`is_enabled`
+    reports whether a usable endpoint + key are present.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        *,
+        timeout: int = LIST_TIMEOUT,
+    ):
+        resolved_url = (
+            base_url if base_url is not None else os.environ.get(LLM_API_URL_ENV, "")
+        )
+        self.base_url = resolved_url.rstrip("/")
+        self.api_key = _read_api_key(api_key)
+        self.timeout = timeout
+
+    @classmethod
+    def from_env(cls, *, timeout: int = LIST_TIMEOUT) -> "MCPClient":
+        """Construct a client from the framework-injected environment."""
+        return cls(timeout=timeout)
+
+    def is_enabled(self) -> bool:
+        """Whether a usable gateway endpoint and key are configured."""
+        return bool(self.base_url and self.api_key)
+
+    def headers(self, extra: dict[str, str] | None = None) -> dict[str, str]:
+        """Auth headers for a gateway request."""
+        if not self.api_key:
+            raise MCPGatewayError(
+                f"Neither {LLM_API_KEY_FILE_ENV} nor {LLM_API_KEY_ENV} is set; "
+                "MCP gateway is unavailable"
+            )
+        result = {"Authorization": f"Bearer {self.api_key}"}
+        if extra:
+            result.update(extra)
+        return result
+
+    def _url(self, path: str) -> str:
+        if not self.base_url:
+            raise MCPGatewayError(
+                f"{LLM_API_URL_ENV} is not set; MCP gateway is unavailable"
+            )
+        return f"{self.base_url}/{path.lstrip('/')}"
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        timeout: int | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Make an authenticated gateway request, returning parsed JSON."""
+        if not self.is_enabled():
+            raise MCPGatewayError(
+                f"MCP gateway is not configured; set {LLM_API_URL_ENV} and "
+                f"{LLM_API_KEY_FILE_ENV} (or {LLM_API_KEY_ENV})"
+            )
+        try:
+            response = http_requests.request(
+                method,
+                self._url(path),
+                headers=self.headers(),
+                timeout=timeout if timeout is not None else self.timeout,
+                **kwargs,
+            )
+            response.raise_for_status()
+        except http_requests.RequestException as e:
+            raise MCPGatewayError(
+                f"MCP gateway request {method} {path} failed: {e}"
+            ) from e
+        try:
+            return response.json()
+        except ValueError as e:
+            raise MCPGatewayError(
+                f"MCP gateway returned non-JSON response for {method} {path}: {e}"
+            ) from e
+
+    def list_tools(self, server: str | None = None) -> list[dict[str, Any]]:
+        """List tools available to this key, optionally filtered to one server.
+
+        Args:
+            server: MCP server name, alias or id to filter by (optional).
+
+        Returns:
+            List of tool dicts with ``name``, ``description``,
+            ``inputSchema`` and ``mcp_info`` (owning server's ``server_id`` /
+            ``alias``).
+        """
+        params = {"mcp_server_name": server} if server else None
+        payload = self._request("GET", TOOLS_LIST_PATH, params=params)
+        tools = payload.get("tools", []) if isinstance(payload, dict) else []
+        return tools if isinstance(tools, list) else []
+
+    def available_names(self, server: str | None = None) -> list[str]:
+        """Sorted tool names available to this key."""
+        return sorted(
+            t["name"]
+            for t in self.list_tools(server)
+            if isinstance(t, dict) and t.get("name")
+        )
+
+    def resolve_server(self, tool_name: str, server: str | None = None) -> str:
+        """Resolve the ``server_id`` to call ``tool_name`` on.
+
+        Uses the ``mcp_info`` attached by ``list_tools``. Fails if the tool is
+        unknown or ambiguous without an explicit ``server`` hint.
+        """
+        candidates = [
+            t
+            for t in self.list_tools(server)
+            if isinstance(t, dict) and t.get("name") == tool_name
+        ]
+        if not candidates:
+            scope = f" on server '{server}'" if server else ""
+            raise MCPGatewayError(
+                f"Tool '{tool_name}' not found{scope}. "
+                "Run `libCRS mcp list` to see available tools."
+            )
+        if len(candidates) > 1 and server is None:
+            owners = sorted(
+                {
+                    (
+                        (c.get("mcp_info") or {}).get("alias")
+                        or (c.get("mcp_info") or {}).get("server_id")
+                        or "?"
+                    )
+                    for c in candidates
+                }
+            )
+            raise MCPGatewayError(
+                f"Tool '{tool_name}' is provided by multiple servers "
+                f"({', '.join(owners)}); pass --server to disambiguate."
+            )
+        info = candidates[0].get("mcp_info") or {}
+        return info.get("alias") or info.get("server_id") or server or ""
+
+    def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        server: str | None = None,
+        *,
+        timeout: int | None = None,
+    ) -> Any:
+        """Call an MCP tool through the gateway, returning the parsed result.
+
+        Args:
+            name: Tool name (as shown by ``list_tools``).
+            arguments: Tool arguments (JSON object).
+            server: Server name/alias/id hint; resolved automatically when the
+                tool name is unambiguous.
+            timeout: Request timeout in seconds (defaults to generous
+                :data:`CALL_TIMEOUT`).
+
+        Returns:
+            Parsed JSON result (MCP ``CallToolResult`` object).
+        """
+        server_id = server or self.resolve_server(name)
+        if not server_id:
+            raise MCPGatewayError(f"Could not resolve a server for tool '{name}'.")
+        return self._request(
+            "POST",
+            TOOLS_CALL_PATH,
+            timeout=CALL_TIMEOUT if timeout is None else timeout,
+            json={"server_id": server_id, "name": name, "arguments": arguments or {}},
+        )
+
+    def describe(self, name: str, server: str | None = None) -> dict[str, Any]:
+        """Return the schema entry for one tool (for ``libCRS mcp describe``)."""
+        for tool in self.list_tools(server):
+            if isinstance(tool, dict) and tool.get("name") == name:
+                return tool
+        scope = f" on server '{server}'" if server else ""
+        raise MCPGatewayError(
+            f"Tool '{name}' not found{scope}. "
+            "Run `libCRS mcp list` to see available tools."
+        )

--- a/libCRS/tests/test_mcp.py
+++ b/libCRS/tests/test_mcp.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: MIT
+"""Tests for libCRS.mcp (MCP gateway client) and the `libCRS mcp` CLI."""
+
+import json
+
+import pytest
+
+import libCRS.mcp as mcp_mod
+from libCRS.mcp import MCPClient, MCPGatewayError
+
+
+class _FakeResponse:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import requests as http_requests
+
+            raise http_requests.HTTPError(f"HTTP {self.status_code}")
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+def _make_client(monkeypatch, key="sk-test"):
+    monkeypatch.setenv("OSS_CRS_LLM_API_URL", "http://litellm:4000")
+    monkeypatch.setenv("OSS_CRS_LLM_API_KEY", key)
+    monkeypatch.delenv("OSS_CRS_LLM_API_KEY_FILE", raising=False)
+    return MCPClient.from_env()
+
+
+def _stub_request(monkeypatch, handler):
+    calls = []
+
+    def fake_request(method, url, **kwargs):
+        calls.append((method, url, kwargs))
+        return handler(method, url, kwargs)
+
+    monkeypatch.setattr(mcp_mod.http_requests, "request", fake_request)
+    return calls
+
+
+def test_disabled_without_env(monkeypatch):
+    monkeypatch.delenv("OSS_CRS_LLM_API_URL", raising=False)
+    monkeypatch.delenv("OSS_CRS_LLM_API_KEY", raising=False)
+    monkeypatch.delenv("OSS_CRS_LLM_API_KEY_FILE", raising=False)
+    client = MCPClient.from_env()
+    assert not client.is_enabled()
+    with pytest.raises(MCPGatewayError):
+        client.list_tools()
+
+
+def test_key_prefers_secret_file(monkeypatch, tmp_path):
+    key_file = tmp_path / "api_key"
+    key_file.write_text("sk-from-file\n")
+    monkeypatch.setenv("OSS_CRS_LLM_API_URL", "http://litellm:4000")
+    monkeypatch.setenv("OSS_CRS_LLM_API_KEY_FILE", str(key_file))
+    monkeypatch.setenv("OSS_CRS_LLM_API_KEY", "sk-from-env")
+    assert MCPClient.from_env().api_key == "sk-from-file"
+
+
+def test_list_tools_parses_names(monkeypatch):
+    client = _make_client(monkeypatch)
+    payload = {
+        "tools": [
+            {
+                "name": "b_tool",
+                "description": "B",
+                "mcp_info": {"alias": "semgrep", "server_id": "uuid-1"},
+            },
+            {
+                "name": "a_tool",
+                "description": "A",
+                "mcp_info": {"alias": "semgrep", "server_id": "uuid-1"},
+            },
+        ]
+    }
+    calls = _stub_request(monkeypatch, lambda m, u, k: _FakeResponse(payload))
+    assert client.available_names() == ["a_tool", "b_tool"]
+    assert calls[0][0] == "GET"
+    assert calls[0][1].endswith("/mcp-rest/tools/list")
+    assert calls[0][2]["headers"]["Authorization"] == "Bearer sk-test"
+
+
+def test_list_tools_server_filter(monkeypatch):
+    client = _make_client(monkeypatch)
+    calls = _stub_request(monkeypatch, lambda m, u, k: _FakeResponse({"tools": []}))
+    client.list_tools("semgrep")
+    assert calls[0][2]["params"] == {"mcp_server_name": "semgrep"}
+
+
+def test_call_tool_posts_server_name_and_args(monkeypatch):
+    client = _make_client(monkeypatch)
+    seen = {}
+
+    def handler(method, url, kwargs):
+        if method == "GET":
+            return _FakeResponse(
+                {
+                    "tools": [
+                        {
+                            "name": "semgrep_scan",
+                            "mcp_info": {"alias": "semgrep", "server_id": "uuid-1"},
+                        }
+                    ]
+                }
+            )
+        seen.update(kwargs.get("json", {}))
+        return _FakeResponse({"content": [{"type": "text", "text": "ok"}]})
+
+    _stub_request(monkeypatch, handler)
+    out = client.call_tool("semgrep_scan", {"code_files": []})
+    assert out == {"content": [{"type": "text", "text": "ok"}]}
+    assert seen == {
+        "server_id": "semgrep",
+        "name": "semgrep_scan",
+        "arguments": {"code_files": []},
+    }
+
+
+def test_call_tool_ambiguous_without_server(monkeypatch):
+    client = _make_client(monkeypatch)
+    _stub_request(
+        monkeypatch,
+        lambda m, u, k: _FakeResponse(
+            {
+                "tools": [
+                    {"name": "scan", "mcp_info": {"alias": "a", "server_id": "1"}},
+                    {"name": "scan", "mcp_info": {"alias": "b", "server_id": "2"}},
+                ]
+            }
+        ),
+    )
+    with pytest.raises(MCPGatewayError, match="multiple servers"):
+        client.call_tool("scan", {})
+
+
+def test_call_tool_unknown(monkeypatch):
+    client = _make_client(monkeypatch)
+    _stub_request(monkeypatch, lambda m, u, k: _FakeResponse({"tools": []}))
+    with pytest.raises(MCPGatewayError, match="not found"):
+        client.call_tool("nope", {})
+
+
+def test_http_error_surfaces_as_gateway_error(monkeypatch):
+    client = _make_client(monkeypatch)
+    _stub_request(monkeypatch, lambda m, u, k: _FakeResponse({}, status=500))
+    with pytest.raises(MCPGatewayError, match="failed"):
+        client.list_tools()
+
+
+def test_extract_result_text_prefers_text_blocks():
+    from libCRS.cli.main import _extract_result_text
+
+    result = {
+        "content": [{"type": "text", "text": "hello"}, {"type": "image", "data": "x"}]
+    }
+    text = _extract_result_text(result)
+    assert "hello" in text
+    assert '"image"' in text or "image" in text
+
+
+def test_extract_result_text_falls_back_to_structured():
+    from libCRS.cli.main import _extract_result_text
+
+    assert _extract_result_text({"structuredContent": {"a": 1}}) == (
+        json.dumps({"a": 1}, indent=2)
+    )
+    assert _extract_result_text("plain") == "plain"
+
+
+def test_print_truncated(capsys):
+    from libCRS.cli.main import _print_truncated
+
+    _print_truncated("abcdef", 4)
+    out = capsys.readouterr().out
+    assert out.startswith("abcd")
+    assert "truncated" in out
+    _print_truncated("abcdef", 0)
+    assert capsys.readouterr().out == "abcdef\n"

--- a/oss_crs/src/config/crs_compose.py
+++ b/oss_crs/src/config/crs_compose.py
@@ -179,6 +179,7 @@ class CRSComposeConfig(BaseModel):
     oss_crs_infra: ResourceConfig
     crs_entries: dict[str, CRSEntry] = Field(default_factory=dict)
     llm_config: Optional[LLMConfig] = None
+    mcp_servers: Optional[list[str]] = None
 
     @field_validator("docker_registry")
     @classmethod
@@ -217,10 +218,12 @@ class CRSComposeConfig(BaseModel):
         DOCKER_REGISTRY = "docker_registry"
         OSS_CRS_INFRA = "oss_crs_infra"
         LLM_CONFIG = "llm_config"
+        MCP_SERVERS = "mcp_servers"
         run_env = data.get(RUN_ENV)
         docker_registry = data.get(DOCKER_REGISTRY)
         oss_crs_infra = data.get(OSS_CRS_INFRA)
         llm_config = data.get(LLM_CONFIG)
+        mcp_servers = data.get(MCP_SERVERS)
         # Backward compatibility: old llm_config format
         # llm_config:
         #   litellm_config: /path/to/config.yaml
@@ -235,7 +238,13 @@ class CRSComposeConfig(BaseModel):
                     }
                 }
 
-        reserved_keys = {RUN_ENV, DOCKER_REGISTRY, OSS_CRS_INFRA, LLM_CONFIG}
+        reserved_keys = {
+            RUN_ENV,
+            DOCKER_REGISTRY,
+            OSS_CRS_INFRA,
+            LLM_CONFIG,
+            MCP_SERVERS,
+        }
         crs_entries = {
             key: value for key, value in data.items() if key not in reserved_keys
         }
@@ -246,6 +255,7 @@ class CRSComposeConfig(BaseModel):
             OSS_CRS_INFRA: oss_crs_infra,
             "crs_entries": crs_entries,
             LLM_CONFIG: llm_config,
+            MCP_SERVERS: mcp_servers,
         }
         config = cls.model_validate(payload)
 

--- a/oss_crs/src/config/mcp.py
+++ b/oss_crs/src/config/mcp.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: MIT
+"""MCP server configuration and registry.
+
+This module provides the schema for MCP server definitions (stored in
+``registry/mcp/<name>.yaml``) and the registry that loads and validates them.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+import yaml
+from pydantic import BaseModel, field_validator
+
+
+class MCPServerConfig(BaseModel):
+    """Configuration for a single MCP server.
+
+    Each MCP server is defined by a YAML file in ``registry/mcp/``.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    name: str
+    image: str
+    url: str
+    source_path: Optional[str] = None
+    command: Optional[list[str]] = None
+    transport: Optional[str] = None
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        if not v or not v.replace("_", "").isalnum():
+            raise ValueError(
+                "MCP server name must be a non-empty alphanumeric string "
+                "with optional underscores"
+            )
+        return v
+
+    @field_validator("source_path")
+    @classmethod
+    def validate_source_path(cls, v: Optional[str]) -> Optional[str]:
+        if not v:
+            return None
+        if not v.startswith("/"):
+            raise ValueError(
+                f"MCP server source_path must be an absolute path, got: {v}"
+            )
+        return v
+
+    @field_validator("transport")
+    @classmethod
+    def validate_transport(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        if v not in ("http", "sse", "streamable-http"):
+            raise ValueError(
+                f"MCP server transport must be one of 'http', 'sse', "
+                f"'streamable-http', got: {v}"
+            )
+        return v
+
+    @field_validator("image")
+    @classmethod
+    def validate_image(cls, v: str) -> str:
+        if not v:
+            raise ValueError("MCP server image cannot be empty")
+        return v
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, v: str) -> str:
+        if not v.startswith(("http://", "https://")):
+            raise ValueError("MCP server URL must start with http:// or https://")
+        return v
+
+
+class MCPRegistry:
+    """Registry of available MCP servers.
+
+    Loads MCP server definitions from ``registry/mcp/*.yaml`` and provides
+    lookup by name.
+    """
+
+    def __init__(self, registry_dir: Path):
+        self.registry_dir = registry_dir
+        self._servers: dict[str, MCPServerConfig] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if not self.registry_dir.exists():
+            return
+
+        for yaml_file in sorted(self.registry_dir.glob("*.yaml")):
+            with open(yaml_file) as f:
+                data = yaml.safe_load(f)
+
+            if not data:
+                continue
+
+            server = MCPServerConfig(**data)
+            if server.name in self._servers:
+                raise ValueError(
+                    f"Duplicate MCP server name '{server.name}' found in {yaml_file}"
+                )
+            self._servers[server.name] = server
+
+    def get(self, name: str) -> MCPServerConfig:
+        """Get an MCP server configuration by name.
+
+        Raises:
+            ValueError: If the MCP server is not found in the registry.
+        """
+        if name not in self._servers:
+            available = sorted(self._servers.keys())
+            raise ValueError(
+                f"MCP server '{name}' not found in registry. "
+                f"Available MCP servers: {available}"
+            )
+        return self._servers[name]
+
+    def list_servers(self) -> list[MCPServerConfig]:
+        """List all registered MCP servers."""
+        return list(self._servers.values())
+
+    def __len__(self) -> int:
+        return len(self._servers)
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._servers
+
+
+def get_default_registry_dir() -> Path:
+    """Get the default MCP registry directory."""
+    return Path(__file__).resolve().parents[3] / "registry" / "mcp"
+
+
+def load_mcp_servers(
+    mcp_server_names: Optional[list[str]],
+    registry_dir: Optional[Path] = None,
+) -> list[MCPServerConfig]:
+    """Load MCP server configurations by name.
+
+    Args:
+        mcp_server_names: List of MCP server names to load.
+        registry_dir: Optional path to the registry directory.
+            Defaults to ``registry/mcp`` in the repo root.
+
+    Returns:
+        List of resolved MCPServerConfig objects.
+
+    Raises:
+        ValueError: If any MCP server name is not found in the registry.
+    """
+    if not mcp_server_names:
+        return []
+
+    if registry_dir is None:
+        registry_dir = get_default_registry_dir()
+
+    registry = MCPRegistry(registry_dir)
+
+    servers = []
+    for name in mcp_server_names:
+        server = registry.get(name)
+        servers.append(server)
+
+    return servers

--- a/oss_crs/src/templates/oss_crs_mcp_hook.py
+++ b/oss_crs/src/templates/oss_crs_mcp_hook.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: MIT
+"""oss-crs LiteLLM hook: MCP CLI usage injection.
+
+Loaded by the LiteLLM proxy via ``litellm_settings.callbacks`` (written by
+``oss_crs.src.templates.renderer.modify_litellm_config_for_mcp``). On every
+request it appends a short system note teaching the agent the ``libCRS mcp``
+CLI, through which all framework-registered MCP tools are reachable.
+
+This module must stay self-contained (stdlib + litellm only): LiteLLM loads
+it with ``importlib``/``exec_module`` from beside ``config.yaml``.
+"""
+
+from typing import Any, Dict, List, Optional
+
+# litellm is intentionally not a project dependency: this module is loaded
+# at runtime inside the LiteLLM sidecar
+from litellm.integrations.custom_logger import CustomLogger  # type: ignore[import-not-found]
+
+INSTRUCTION = (
+    "[oss-crs] Additional analysis tools are available via the `libCRS mcp` "
+    "CLI:\n"
+    "- `libCRS mcp list` -- list available tools\n"
+    "- `libCRS mcp describe <name>` -- show a tool's input schema\n"
+    "- `libCRS mcp call <name> --args '<json>'` -- invoke a tool "
+    "(add --json for raw output; large outputs are truncated, rerun with "
+    "--max-output-chars 0 for the full output).\n"
+    "You are strongly encouraged to make them part of your workflow -- they"
+    "return targeted results far more cheaply than dumping whole files into"
+    "context.\n"
+)
+
+# Substring guard for idempotency (also matched by user-supplied text that
+# already documents the CLI, in which case injection is redundant).
+_SENTINEL = "libCRS mcp"
+
+
+def _system_has_instruction(system: Any) -> bool:
+    if system is None:
+        return False
+    if isinstance(system, str):
+        return _SENTINEL in system
+    if isinstance(system, list):
+        for block in system:
+            if isinstance(block, dict):
+                if _SENTINEL in str(block.get("text", "")):
+                    return True
+            elif isinstance(block, str) and _SENTINEL in block:
+                return True
+    return False
+
+
+def _with_instruction(system: Any) -> Any:
+    if system is None:
+        return INSTRUCTION
+    if isinstance(system, str):
+        return system + "\n\n" + INSTRUCTION
+    if isinstance(system, list):
+        return [*system, {"type": "text", "text": INSTRUCTION}]
+    return system
+
+
+def _completion_system_content(messages: List[Any]) -> Optional[str]:
+    for message in messages:
+        if isinstance(message, dict) and message.get("role") == "system":
+            content = message.get("content")
+            if isinstance(content, str):
+                return content
+            if isinstance(content, list):
+                texts = [
+                    p.get("text", "")
+                    for p in content
+                    if isinstance(p, dict) and p.get("type") == "text"
+                ]
+                return "\n".join(texts)
+    return None
+
+
+class OssCrsMcpHook(CustomLogger):
+    """Appends MCP CLI usage docs to the system prompt on every turn."""
+
+    async def async_pre_call_hook(
+        self,
+        user_api_key_dict: Any,
+        cache: Any,
+        data: Dict[str, Any],
+        call_type: Any,
+    ) -> Optional[Dict[str, Any]]:
+        """Hook for ``/chat/completions``-family requests."""
+        try:
+            if not isinstance(data, dict):
+                return data
+            messages = data.get("messages")
+            if not isinstance(messages, list):
+                return data
+            if _system_has_instruction(data.get("system")) or _system_has_instruction(
+                _completion_system_content(messages)
+            ):
+                return data
+            if "system" in data:
+                data["system"] = _with_instruction(data.get("system"))
+                return data
+            for message in messages:
+                if isinstance(message, dict) and message.get("role") == "system":
+                    content = message.get("content")
+                    if isinstance(content, str):
+                        message["content"] = content + "\n\n" + INSTRUCTION
+                    elif isinstance(content, list):
+                        content.append({"type": "text", "text": INSTRUCTION})
+                    else:
+                        message["content"] = INSTRUCTION
+                    break
+            else:
+                messages.insert(0, {"role": "system", "content": INSTRUCTION})
+            return data
+        except Exception:
+            return data
+
+    async def async_pre_request_hook(
+        self, model: str, messages: List[Any], kwargs: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """Hook for ``/v1/messages``-family (Anthropic passthrough) requests.
+
+        ``messages`` itself is not re-read downstream, so only ``kwargs``
+        (notably ``system``) is modified.
+        """
+        try:
+            if not isinstance(kwargs, dict):
+                return kwargs
+            if _system_has_instruction(kwargs.get("system")):
+                return kwargs
+            kwargs["system"] = _with_instruction(kwargs.get("system"))
+            return kwargs
+        except Exception:
+            return kwargs
+
+
+proxy_handler_instance = OssCrsMcpHook()

--- a/oss_crs/src/templates/renderer.py
+++ b/oss_crs/src/templates/renderer.py
@@ -6,6 +6,7 @@ import os
 import yaml
 
 from ..config.crs import CRSType, OSS_CRS_INFRA_PREFIX
+from ..config.mcp import get_default_registry_dir, load_mcp_servers
 from ..constants import (
     EXCHANGE_DIR_NAMES,
     LITELLM_INTERNAL_URL,
@@ -249,6 +250,85 @@ def prepare_llm_context(
     raise RuntimeError(f"Unsupported LLM mode: {crs_compose.llm.mode}")
 
 
+# LiteLLM hook that teaches agents the `libCRS mcp` CLI on the first turn.
+# The module is copied next to the generated LiteLLM config so LiteLLM's
+# `get_instance_fn` can load it from beside config.yaml; `callbacks` must
+# reference the instance (not the class) or the proxy silently never runs it.
+MCP_HOOK_FILENAME = "oss_crs_mcp_hook.py"
+MCP_HOOK_CALLBACK = "oss_crs_mcp_hook.proxy_handler_instance"
+
+
+def _hook_source_path() -> Path:
+    return CUR_DIR / MCP_HOOK_FILENAME
+
+
+def modify_litellm_config_for_mcp(
+    litellm_config_path: Path,
+    mcp_server_configs: list,
+    output_path: Path,
+) -> tuple[Path, Path]:
+    """Modify LiteLLM config to add MCP server connections.
+
+    Reads the original LiteLLM config, registers each MCP server on the
+    proxy's MCP gateway (streamable HTTP, usable by this run's virtual keys),
+    points ``litellm_settings.callbacks`` at the oss-crs prompt hook, writes
+    the modified config to the specified output path, and copies the hook
+    module alongside it.
+
+    Args:
+        litellm_config_path: Path to the original LiteLLM config.
+        mcp_server_configs: List of MCPServerConfig objects to add.
+        output_path: Path where the modified config will be written.
+
+    Returns:
+        Tuple of (modified LiteLLM config path, hook module path).
+    """
+    # Read original config
+    with open(litellm_config_path) as f:
+        config = yaml.safe_load(f) or {}
+
+    # Drop the legacy key: it was never a LiteLLM setting and is ignored.
+    general_settings = config.get("general_settings", {})
+    if general_settings:
+        config["general_settings"] = general_settings
+    else:
+        config.pop("general_settings", None)
+
+    # Add mcp_servers section. Transport defaults to SSE in LiteLLM, but our
+    # registry servers speak streamable HTTP; allow_all_keys lets this run's
+    # per-CRS virtual keys reach the gateway without per-key grants.
+    mcp_servers = {}
+    for mcp_server in mcp_server_configs:
+        mcp_servers[mcp_server.name] = {
+            "url": mcp_server.url,
+            "transport": mcp_server.transport or "http",
+            "allow_all_keys": True,
+        }
+    config["mcp_servers"] = mcp_servers
+
+    # Register the prompt hook (merged with, never replacing, existing config).
+    litellm_settings = config.get("litellm_settings", {})
+    existing_callbacks = litellm_settings.get("callbacks", [])
+    if isinstance(existing_callbacks, str):
+        existing_callbacks = [existing_callbacks]
+    callbacks = list(existing_callbacks) if isinstance(existing_callbacks, list) else []
+    if MCP_HOOK_CALLBACK not in callbacks:
+        callbacks.append(MCP_HOOK_CALLBACK)
+    litellm_settings["callbacks"] = callbacks
+    config["litellm_settings"] = litellm_settings
+
+    # Write modified config
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+
+    # Copy the hook module next to the config so LiteLLM can load it.
+    hook_path = output_path.parent / MCP_HOOK_FILENAME
+    hook_path.write_bytes(_hook_source_path().read_bytes())
+
+    return output_path, hook_path
+
+
 # Maps each exchange data type to the post-processor CRS attribute that handles it.
 # Types not listed here (or whose processor is absent) pass through from exchange_dir.
 _DATA_TYPE_PROCESSOR: dict[str, str] = {
@@ -441,7 +521,6 @@ def render_run_crs_compose_docker_compose(
     llm_context = prepare_llm_context(tmp_docker_compose, crs_compose)
     if llm_context:
         context["llm_context"] = llm_context
-
     module_envs: dict[str, dict[str, str]] = {}
     warnings: list[str] = []
     for crs in crs_compose.crs_list:
@@ -480,6 +559,31 @@ def render_run_crs_compose_docker_compose(
             module_envs[service_name] = env_plan.effective_env
             warnings.extend(env_plan.warnings)
     context["module_envs"] = module_envs
+
+    # Load MCP server configurations (if any)
+    mcp_server_names = getattr(crs_compose.config, "mcp_servers", None) or []
+    if mcp_server_names:
+        mcp_servers = load_mcp_servers(
+            mcp_server_names,
+            get_default_registry_dir(),
+        )
+        context["mcp_servers"] = mcp_servers
+
+        # Modify LiteLLM config to include MCP server connections
+        if llm_context is not None and llm_context.get("litellm_config_path"):
+            if tmp_docker_compose.dir is None:
+                raise RuntimeError(
+                    "Temporary docker compose directory was not initialized"
+                )
+            original_config_path = Path(llm_context["litellm_config_path"])
+            modified_config_path = tmp_docker_compose.dir / "litellm-config-mcp.yaml"
+            _, hook_path = modify_litellm_config_for_mcp(
+                original_config_path,
+                mcp_servers,
+                modified_config_path,
+            )
+            llm_context["litellm_config_path"] = str(modified_config_path)
+            llm_context["mcp_hook_path"] = str(hook_path)
 
     rendered = render_template(template_path, context)
 

--- a/oss_crs/src/templates/run-crs-compose.docker-compose.yaml.j2
+++ b/oss_crs/src/templates/run-crs-compose.docker-compose.yaml.j2
@@ -104,6 +104,9 @@ services:
 {%- endfor %}
     volumes:
       - {{ llm_context.litellm_config_path }}:/app/config.yaml:ro
+{%- if llm_context.mcp_hook_path is defined %}
+      - {{ llm_context.mcp_hook_path }}:/app/oss_crs_mcp_hook.py:ro
+{%- endif %}
     networks:
       {{ crs_compose_name }}-infra-only-network:
       {{ crs_compose_name }}-network:
@@ -366,6 +369,28 @@ services:
         aliases:
 {%- for crs in crs_list %}
           - runner-sidecar.{{ crs.name }}
+{%- endfor %}
+{%- endif %}
+  ###########################################
+  # MCP SERVERS
+  ###########################################
+{%- if mcp_servers is defined and mcp_servers %}
+{%- for mcp_server in mcp_servers %}
+  mcp-{{ mcp_server.name }}:
+    image: {{ mcp_server.image }}
+    attach: false
+    restart: on-failure:3
+{%- if mcp_server.command %}
+    command: {{ mcp_server.command | tojson }}
+{%- endif %}
+{%- if mcp_server.source_path %}
+    volumes:
+      - {{ target_source_path }}:{{ mcp_server.source_path }}:ro
+{%- endif %}
+    networks:
+      {{ crs_compose_name }}-infra-only-network:
+        aliases:
+          - {{ mcp_server.name }}
 {%- endfor %}
 {%- endif %}
 {%- if llm_context is defined %}

--- a/oss_crs/tests/unit/test_mcp.py
+++ b/oss_crs/tests/unit/test_mcp.py
@@ -1,0 +1,482 @@
+# SPDX-License-Identifier: MIT
+"""Tests for MCP server configuration and registry."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from oss_crs.src.config.mcp import (
+    MCPRegistry,
+    MCPServerConfig,
+    get_default_registry_dir,
+    load_mcp_servers,
+)
+
+
+class TestMCPServerConfig:
+    def test_valid_config(self):
+        config = MCPServerConfig(
+            name="ripgrep",
+            image="ghcr.io/oss-crs/mcp-ripgrep:latest",
+            url="http://ripgrep:8000/mcp",
+            source_path="/OSS_CRS_TARGET_SOURCE",
+        )
+        assert config.name == "ripgrep"
+        assert config.source_path == "/OSS_CRS_TARGET_SOURCE"
+
+    def test_source_path_defaults_none(self):
+        config = MCPServerConfig(
+            name="test",
+            image="some-image",
+            url="http://test:8000/mcp",
+        )
+        assert config.source_path is None
+
+    def test_source_path_empty_string_is_none(self):
+        # empty string means "do not bind mount source"
+        config = MCPServerConfig(
+            name="test",
+            image="some-image",
+            url="http://test:8000/mcp",
+            source_path="",
+        )
+        assert config.source_path is None
+
+    def test_source_path_relative_rejected(self):
+        with pytest.raises(ValueError, match="absolute"):
+            MCPServerConfig(
+                name="test",
+                image="some-image",
+                url="http://test:8000/mcp",
+                source_path="src",
+            )
+
+    def test_unknown_field_rejected(self):
+        # extra="forbid" catches stale/unknown registry fields at load time
+        with pytest.raises(ValueError):
+            MCPServerConfig(
+                name="test",
+                image="some-image",
+                url="http://test:8000/mcp",
+                requires_source=True,
+            )
+
+    def test_command_field(self):
+        config = MCPServerConfig(
+            name="semgrep",
+            image="semgrep/semgrep",
+            url="http://semgrep:8000/mcp",
+            command=["semgrep", "mcp"],
+        )
+        assert config.command == ["semgrep", "mcp"]
+
+    def test_command_defaults_none(self):
+        config = MCPServerConfig(
+            name="test",
+            image="some-image",
+            url="http://test:8000/mcp",
+        )
+        assert config.command is None
+
+    def test_invalid_name_rejected(self):
+        with pytest.raises(ValueError):
+            MCPServerConfig(
+                name="invalid name with spaces",
+                image="some-image",
+                url="http://test:8000/mcp",
+            )
+
+    def test_hyphenated_name_rejected(self):
+        with pytest.raises(ValueError, match="alphanumeric"):
+            MCPServerConfig(
+                name="ast-grep",
+                image="some-image",
+                url="http://ast-grep:8000/mcp",
+            )
+
+    def test_underscore_name_accepted(self):
+        config = MCPServerConfig(
+            name="ast_grep",
+            image="some-image",
+            url="http://ast_grep:8000/mcp",
+        )
+        assert config.name == "ast_grep"
+
+    def test_invalid_url_rejected(self):
+        with pytest.raises(ValueError):
+            MCPServerConfig(
+                name="test",
+                image="some-image",
+                url="ftp://test:8000/mcp",
+            )
+
+    def test_empty_image_rejected(self):
+        with pytest.raises(ValueError):
+            MCPServerConfig(
+                name="test",
+                image="",
+                url="http://test:8000/mcp",
+            )
+
+
+class TestMCPRegistry:
+    def _write_registry(self, tmp_path: Path, servers: list) -> Path:
+        registry_dir = tmp_path / "registry" / "mcp"
+        registry_dir.mkdir(parents=True)
+        for server in servers:
+            name = server["name"]
+            with open(registry_dir / f"{name}.yaml", "w") as f:
+                yaml.dump(server, f)
+        return registry_dir
+
+    def test_load_and_get(self, tmp_path):
+        registry_dir = self._write_registry(
+            tmp_path,
+            [
+                {
+                    "name": "ripgrep",
+                    "image": "ghcr.io/oss-crs/mcp-ripgrep:latest",
+                    "url": "http://ripgrep:8000/mcp",
+                    "source_path": "/OSS_CRS_TARGET_SOURCE",
+                }
+            ],
+        )
+        registry = MCPRegistry(registry_dir)
+        assert len(registry) == 1
+        assert "ripgrep" in registry
+
+        config = registry.get("ripgrep")
+        assert config.name == "ripgrep"
+        assert config.source_path == "/OSS_CRS_TARGET_SOURCE"
+
+    def test_get_missing_server_raises(self, tmp_path):
+        registry_dir = self._write_registry(tmp_path, [])
+        registry = MCPRegistry(registry_dir)
+        with pytest.raises(ValueError, match="not found in registry"):
+            registry.get("nonexistent")
+
+    def test_duplicate_names_rejected(self, tmp_path):
+        registry_dir = tmp_path / "registry" / "mcp"
+        registry_dir.mkdir(parents=True)
+        for filename in ("dup.yaml", "dup-2.yaml"):
+            with open(registry_dir / filename, "w") as f:
+                yaml.dump(
+                    {
+                        "name": "dup",
+                        "image": "some-image",
+                        "url": "http://dup:8000/mcp",
+                    },
+                    f,
+                )
+        with pytest.raises(ValueError, match="Duplicate MCP server name"):
+            MCPRegistry(registry_dir)
+
+    def test_empty_registry_dir(self, tmp_path):
+        registry = MCPRegistry(tmp_path / "nonexistent")
+        assert len(registry) == 0
+
+    def test_list_servers(self, tmp_path):
+        registry_dir = self._write_registry(
+            tmp_path,
+            [
+                {
+                    "name": "a",
+                    "image": "img-a",
+                    "url": "http://a:8000/mcp",
+                },
+                {
+                    "name": "b",
+                    "image": "img-b",
+                    "url": "http://b:8000/mcp",
+                },
+            ],
+        )
+        registry = MCPRegistry(registry_dir)
+        servers = registry.list_servers()
+        assert len(servers) == 2
+        assert {s.name for s in servers} == {"a", "b"}
+
+
+class TestLoadMCPServers:
+    def test_load_none_returns_empty(self):
+        assert load_mcp_servers(None) == []
+
+    def test_load_empty_list_returns_empty(self):
+        assert load_mcp_servers([]) == []
+
+    def test_load_resolves_servers(self, tmp_path):
+        registry_dir = tmp_path / "registry" / "mcp"
+        registry_dir.mkdir(parents=True)
+        with open(registry_dir / "ripgrep.yaml", "w") as f:
+            yaml.dump(
+                {
+                    "name": "ripgrep",
+                    "image": "ghcr.io/oss-crs/mcp-ripgrep:latest",
+                    "url": "http://ripgrep:8000/mcp",
+                    "source_path": "/OSS_CRS_TARGET_SOURCE",
+                },
+                f,
+            )
+
+        servers = load_mcp_servers(["ripgrep"], registry_dir)
+        assert len(servers) == 1
+        assert servers[0].name == "ripgrep"
+
+    def test_load_missing_server_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="not found in registry"):
+            load_mcp_servers(["missing"], tmp_path)
+
+
+class TestDefaultRegistryDir:
+    def test_default_registry_dir_exists_check(self):
+        registry_dir = get_default_registry_dir()
+        # Just verify the path is constructed correctly
+        assert registry_dir.name == "mcp"
+        assert registry_dir.parent.name == "registry"
+
+
+class TestModifyLitellmConfigForMcp:
+    """Test that modify_litellm_config_for_mcp produces a valid LiteLLM config."""
+
+    def _setup(self, tmp_path):
+        from oss_crs.src.templates.renderer import modify_litellm_config_for_mcp
+
+        litellm_file = tmp_path / "litellm.yaml"
+        litellm_file.write_text("model_list: []\n")
+        output_file = tmp_path / "litellm-config-mcp.yaml"
+        return litellm_file, output_file, modify_litellm_config_for_mcp
+
+    def test_modifies_litellm_config(self, tmp_path):
+        litellm_file, output_file, fn = self._setup(tmp_path)
+        mcp_servers = [
+            MCPServerConfig(
+                name="ripgrep",
+                image="ghcr.io/oss-crs/mcp-ripgrep:latest",
+                url="http://ripgrep:8000/mcp",
+            )
+        ]
+        result_path, hook_path = fn(litellm_file, mcp_servers, output_file)
+
+        assert Path(result_path).exists()
+        with open(output_file) as f:
+            config = yaml.safe_load(f)
+        # auto_register_tools is not a LiteLLM setting and must not be emitted
+        assert "auto_register_tools" not in config.get("general_settings", {})
+        assert "ripgrep" in config["mcp_servers"]
+        entry = config["mcp_servers"]["ripgrep"]
+        assert entry["url"] == "http://ripgrep:8000/mcp"
+        # Streamable HTTP: LiteLLM defaults to SSE
+        assert entry["transport"] == "http"
+        # Per-CRS virtual keys need gateway access without per-key grants
+        assert entry["allow_all_keys"] is True
+        # Prompt hook registration (merged, pointing at the instance)
+        callbacks = config["litellm_settings"]["callbacks"]
+        assert "oss_crs_mcp_hook.proxy_handler_instance" in callbacks
+        # Hook module is copied next to the generated config
+        assert Path(hook_path).exists()
+        assert hook_path.parent == output_file.parent
+        assert "proxy_handler_instance" in Path(hook_path).read_text()
+
+    def test_preserves_existing_config(self, tmp_path):
+        litellm_file, output_file, fn = self._setup(tmp_path)
+        mcp_servers = [
+            MCPServerConfig(
+                name="test",
+                image="some-image",
+                url="http://test:8000/mcp",
+            )
+        ]
+        fn(litellm_file, mcp_servers, output_file)
+
+        # Original file should not have MCP servers
+        with open(litellm_file) as f:
+            original_config = yaml.safe_load(f)
+        assert "mcp_servers" not in original_config
+        assert "general_settings" not in original_config
+
+    def test_merges_with_existing_litellm_settings(self, tmp_path):
+        from oss_crs.src.templates.renderer import MCP_HOOK_CALLBACK
+
+        litellm_file = tmp_path / "litellm.yaml"
+        output_file = tmp_path / "litellm-config-mcp.yaml"
+        fn = self._setup(tmp_path)[2]
+        # _setup writes a minimal litellm.yaml; replace it with settings to merge
+        litellm_file.write_text(
+            "model_list: []\n"
+            "litellm_settings:\n"
+            "  ssl_verify: false\n"
+            "  callbacks: [other_module.instance]\n"
+        )
+        from oss_crs.src.config.mcp import MCPServerConfig as Cfg
+
+        fn(
+            litellm_file,
+            [Cfg(name="s", image="img", url="http://s:8000/mcp")],
+            output_file,
+        )
+        with open(output_file) as f:
+            config = yaml.safe_load(f)
+        # Existing settings preserved, hook appended (not replacing)
+        assert config["litellm_settings"]["ssl_verify"] is False
+        assert config["litellm_settings"]["callbacks"] == [
+            "other_module.instance",
+            MCP_HOOK_CALLBACK,
+        ]
+
+
+class TestMcpPromptHook:
+    """Tests for the LiteLLM prompt hook (litellm stubbed out)."""
+
+    @staticmethod
+    def _load_hook():
+        import importlib.util
+        import sys
+        import types
+
+        if "litellm" not in sys.modules:
+            litellm_pkg = types.ModuleType("litellm")
+            integrations = types.ModuleType("litellm.integrations")
+            custom_logger = types.ModuleType("litellm.integrations.custom_logger")
+
+            class CustomLogger:  # minimal stand-in for isinstance checks
+                pass
+
+            custom_logger.CustomLogger = CustomLogger
+            litellm_pkg.integrations = integrations
+            integrations.custom_logger = custom_logger
+            sys.modules["litellm"] = litellm_pkg
+            sys.modules["litellm.integrations"] = integrations
+            sys.modules["litellm.integrations.custom_logger"] = custom_logger
+
+        from oss_crs.src.templates import renderer
+
+        hook_src = renderer._hook_source_path()
+        spec = importlib.util.spec_from_file_location(
+            "oss_crs_mcp_hook_under_test", hook_src
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def test_hook_module_defines_instance(self):
+        hook = self._load_hook()
+        assert isinstance(hook.proxy_handler_instance, hook.OssCrsMcpHook)
+        assert "libCRS mcp" in hook.INSTRUCTION
+
+    def test_pre_call_hook_injects_on_first_turn(self):
+        import asyncio
+
+        hook = self._load_hook()
+        inst = hook.OssCrsMcpHook()
+        data = {"model": "m", "messages": [{"role": "user", "content": "hi"}]}
+        out = asyncio.run(inst.async_pre_call_hook(None, None, data, "completion"))
+        assert out["messages"][0]["role"] == "system"
+        assert "libCRS mcp" in out["messages"][0]["content"]
+
+    def test_pre_call_hook_injects_with_history(self):
+        import asyncio
+
+        hook = self._load_hook()
+        inst = hook.OssCrsMcpHook()
+        data = {
+            "model": "m",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+                {"role": "user", "content": "again"},
+            ],
+        }
+        out = asyncio.run(inst.async_pre_call_hook(None, None, data, "completion"))
+        assert out["messages"][0]["role"] == "system"
+        assert "libCRS mcp" in out["messages"][0]["content"]
+
+    def test_pre_call_hook_idempotent(self):
+        import asyncio
+
+        hook = self._load_hook()
+        inst = hook.OssCrsMcpHook()
+        data = {
+            "model": "m",
+            "messages": [{"role": "user", "content": "hi"}],
+            "system": "existing libCRS mcp docs",
+        }
+        out = asyncio.run(inst.async_pre_call_hook(None, None, data, "completion"))
+        assert out["system"] == "existing libCRS mcp docs"
+
+    def test_pre_request_hook_appends_system(self):
+        import asyncio
+
+        hook = self._load_hook()
+        inst = hook.OssCrsMcpHook()
+        kwargs = {"system": "base instructions"}
+        out = asyncio.run(
+            inst.async_pre_request_hook(
+                "m", [{"role": "user", "content": "hi"}], kwargs
+            )
+        )
+        assert "base instructions" in out["system"]
+        assert "libCRS mcp" in out["system"]
+
+    def test_pre_request_hook_injects_with_history(self):
+        import asyncio
+
+        hook = self._load_hook()
+        inst = hook.OssCrsMcpHook()
+        kwargs = {}
+        messages = [
+            {"role": "user", "content": "a"},
+            {"role": "assistant", "content": "b"},
+            {"role": "user", "content": "c"},
+        ]
+        out = asyncio.run(inst.async_pre_request_hook("m", messages, kwargs))
+        assert "libCRS mcp" in out["system"]
+
+    def test_hooks_fail_open(self):
+        import asyncio
+
+        hook = self._load_hook()
+        inst = hook.OssCrsMcpHook()
+        assert asyncio.run(inst.async_pre_call_hook(None, None, None, "x")) is None
+        kwargs = {"system": "s"}
+        assert asyncio.run(inst.async_pre_request_hook("m", None, kwargs)) is kwargs
+
+
+class TestComposeSchemaWithMcpServers:
+    """Test that the compose schema handles mcp_servers correctly."""
+
+    def _base_compose_data(self, tmp_path):
+        litellm_file = tmp_path / "litellm.yaml"
+        litellm_file.write_text("model_list: []\n")
+        return {
+            "run_env": "local",
+            "docker_registry": "local",
+            "oss_crs_infra": {"cpuset": "0-1", "memory": "8G"},
+            "crs-claude-code": {
+                "cpuset": "2-7",
+                "memory": "16G",
+                "llm_budget": 10,
+            },
+            "llm_config": {
+                "litellm": {
+                    "mode": "internal",
+                    "internal": {"config_path": str(litellm_file)},
+                }
+            },
+        }
+
+    def test_compose_with_mcp_servers(self, tmp_path):
+        from oss_crs.src.config.crs_compose import CRSComposeConfig
+
+        data = self._base_compose_data(tmp_path)
+        data["mcp_servers"] = ["ripgrep", "tree-sitter"]
+
+        config = CRSComposeConfig.from_dict(data)
+        assert config.mcp_servers == ["ripgrep", "tree-sitter"]
+
+    def test_compose_without_mcp_servers(self, tmp_path):
+        from oss_crs.src.config.crs_compose import CRSComposeConfig
+
+        data = self._base_compose_data(tmp_path)
+        config = CRSComposeConfig.from_dict(data)
+        assert config.mcp_servers is None

--- a/oss_crs/tests/unit/test_renderer_run_compose.py
+++ b/oss_crs/tests/unit/test_renderer_run_compose.py
@@ -31,7 +31,9 @@ def _patch_renderer(monkeypatch, build_env_fn=None, llm_context_fn=None):
     )
 
 
-def _make_crs_compose(tmp_path: Path, crs_list: list) -> SimpleNamespace:
+def _make_crs_compose(
+    tmp_path: Path, crs_list: list, mcp_servers: list | None = None
+) -> SimpleNamespace:
     return SimpleNamespace(
         crs_list=crs_list,
         work_dir=SimpleNamespace(
@@ -51,7 +53,8 @@ def _make_crs_compose(tmp_path: Path, crs_list: list) -> SimpleNamespace:
         llm=SimpleNamespace(exists=lambda: False, mode="external"),
         offline=False,
         config=SimpleNamespace(
-            oss_crs_infra=SimpleNamespace(cpuset="0-1", memory="16G")
+            oss_crs_infra=SimpleNamespace(cpuset="0-1", memory="16G"),
+            mcp_servers=mcp_servers,
         ),
     )
 
@@ -1024,3 +1027,161 @@ def test_no_harness_run_does_not_inject_harness_env(
     assert "oss-crs-exchange" in compose_data["services"]
     assert "oss-crs-builder-sidecar" not in compose_data["services"]
     assert "oss-crs-runner-sidecar" not in compose_data["services"]
+
+
+def test_mcp_servers_rendered_in_compose(monkeypatch, tmp_path: Path) -> None:
+    """MCP servers from the compose config are rendered as services."""
+    _patch_renderer(monkeypatch)
+
+    # Create a mock MCP registry entry
+    registry_dir = tmp_path / "registry" / "mcp"
+    registry_dir.mkdir(parents=True)
+    with open(registry_dir / "ripgrep.yaml", "w") as f:
+        yaml.dump(
+            {
+                "name": "ripgrep",
+                "image": "ghcr.io/oss-crs/mcp-ripgrep:latest",
+                "url": "http://ripgrep:8000/mcp",
+                "source_path": "/OSS_CRS_TARGET_SOURCE",
+            },
+            f,
+        )
+
+    # Patch get_default_registry_dir to return our test registry
+    monkeypatch.setattr(
+        "oss_crs.src.templates.renderer.get_default_registry_dir",
+        lambda: registry_dir,
+    )
+
+    crs = _make_crs(tmp_path, "crs-claude-code")
+    crs_compose = _make_crs_compose(tmp_path, [crs], mcp_servers=["ripgrep"])
+    target = _make_target(tmp_path, has_repo=True)
+
+    rendered, warnings = _render(crs_compose, target, tmp_path)
+    assert warnings == []
+
+    compose_data = yaml.safe_load(rendered)
+    services = compose_data["services"]
+
+    # MCP server service should be rendered
+    assert "mcp-ripgrep" in services
+    mcp_service = services["mcp-ripgrep"]
+    assert mcp_service["image"] == "ghcr.io/oss-crs/mcp-ripgrep:latest"
+    # source_path means the target source is mounted at that path
+    assert any(
+        ":/OSS_CRS_TARGET_SOURCE:ro" in v for v in mcp_service.get("volumes", [])
+    )
+    # MCP server should be on the infra-only network
+    assert "proj-infra-only-network" in mcp_service.get("networks", {})
+
+
+def test_mcp_servers_not_rendered_when_empty(monkeypatch, tmp_path: Path) -> None:
+    """No MCP services are rendered when mcp_servers is empty or missing."""
+    _patch_renderer(monkeypatch)
+
+    crs = _make_crs(tmp_path, "crs-claude-code")
+    target = _make_target(tmp_path, has_repo=True)
+
+    # No mcp_servers specified
+    crs_compose = _make_crs_compose(tmp_path, [crs])
+    rendered, _ = _render(crs_compose, target, tmp_path)
+    compose_data = yaml.safe_load(rendered)
+    mcp_services = [
+        name for name in compose_data.get("services", {}) if name.startswith("mcp-")
+    ]
+    assert mcp_services == []
+
+    # Empty mcp_servers list
+    crs_compose = _make_crs_compose(tmp_path, [crs], mcp_servers=[])
+    rendered, _ = _render(crs_compose, target, tmp_path)
+    compose_data = yaml.safe_load(rendered)
+    mcp_services = [
+        name for name in compose_data.get("services", {}) if name.startswith("mcp-")
+    ]
+    assert mcp_services == []
+
+
+def test_mcp_command_rendered(monkeypatch, tmp_path: Path) -> None:
+    """MCP server command override is rendered."""
+    _patch_renderer(monkeypatch)
+
+    # Create mock MCP registry entry with command override
+    registry_dir = tmp_path / "registry" / "mcp"
+    registry_dir.mkdir(parents=True)
+    with open(registry_dir / "semgrep.yaml", "w") as f:
+        yaml.dump(
+            {
+                "name": "semgrep",
+                "image": "semgrep/semgrep",
+                "url": "http://semgrep:8000/mcp",
+                "command": ["semgrep", "mcp"],
+            },
+            f,
+        )
+
+    # Patch get_default_registry_dir to return our test registry
+    monkeypatch.setattr(
+        "oss_crs.src.templates.renderer.get_default_registry_dir",
+        lambda: registry_dir,
+    )
+
+    crs = _make_crs(tmp_path, "crs-claude-code")
+    crs_compose = _make_crs_compose(tmp_path, [crs], mcp_servers=["semgrep"])
+    target = _make_target(tmp_path, has_repo=True)
+
+    rendered, warnings = _render(crs_compose, target, tmp_path)
+    assert warnings == []
+
+    compose_data = yaml.safe_load(rendered)
+    services = compose_data["services"]
+
+    # Semgrep MCP server should be rendered with command override
+    assert "mcp-semgrep" in services
+    semgrep_service = services["mcp-semgrep"]
+    assert semgrep_service["image"] == "semgrep/semgrep"
+    assert semgrep_service["command"] == ["semgrep", "mcp"]
+
+
+def test_mcp_hook_mounted_for_internal_llm(monkeypatch, tmp_path: Path) -> None:
+    """With MCP servers + internal LiteLLM, the prompt hook is mounted."""
+    _patch_renderer(monkeypatch, llm_context_fn=_internal_llm_context(tmp_path))
+
+    # The internal context points at a config file; it must exist for the
+    # MCP config rewrite to read it.
+    (tmp_path / "litellm-config.yaml").write_text("model_list: []\n")
+
+    registry_dir = tmp_path / "registry" / "mcp"
+    registry_dir.mkdir(parents=True)
+    with open(registry_dir / "ripgrep.yaml", "w") as f:
+        yaml.dump(
+            {
+                "name": "ripgrep",
+                "image": "ghcr.io/oss-crs/mcp-ripgrep:latest",
+                "url": "http://ripgrep:8000/mcp",
+                "source_path": "/OSS_CRS_TARGET_SOURCE",
+            },
+            f,
+        )
+    monkeypatch.setattr(
+        "oss_crs.src.templates.renderer.get_default_registry_dir",
+        lambda: registry_dir,
+    )
+
+    crs = _make_crs(tmp_path, "crs-claude-code")
+    crs_compose = _make_crs_compose(tmp_path, [crs], mcp_servers=["ripgrep"])
+    target = _make_target(tmp_path, has_repo=True)
+
+    rendered, warnings = _render(crs_compose, target, tmp_path)
+    assert warnings == []
+
+    compose_data = yaml.safe_load(rendered)
+    litellm_service = compose_data["services"]["oss-crs-litellm"]
+    volumes = litellm_service.get("volumes", [])
+    # Generated MCP config is mounted as the proxy config...
+    assert any(v.endswith(":/app/config.yaml:ro") for v in volumes)
+    # ...and the prompt hook module sits beside it.
+    hook_mounts = [v for v in volumes if v.endswith(":/app/oss_crs_mcp_hook.py:ro")]
+    assert len(hook_mounts) == 1
+    hook_host_path = Path(hook_mounts[0].split(":")[0])
+    assert hook_host_path.exists()
+    assert "proxy_handler_instance" in hook_host_path.read_text()


### PR DESCRIPTION
## Summary

Describe what changed and why.

Add support for running user-defined MCP servers which are registered in registry/mcp/. Discovery of MCP servers is done by using LiteLLM to add mention of the MCP tools in the system prompt, the agent accesses MCP tools via libCRS, and MCP servers are added to the LiteLLM gateway. Addresses #372 

## User Impact

- [X] User-facing change
- [ ] Internal-only change

If user-facing, describe CLI/API/config/docs impact and migration steps.

## Release Note / Changelog

- [X] I updated `CHANGELOG.md` (`[Unreleased]`) for user-facing changes
- [ ] No changelog entry needed (internal-only refactor/test/chore)

If this PR includes deprecation or breaking behavior, include:
- replacement path for users
- planned removal version/release window

## Validation

List tests/checks run and their results.

All tests were run and passed successfully.

## Checklist

- [X] I followed Conventional Commits
- [X] I updated docs for behavior/config/CLI changes
- [X] I added/updated tests for behavior changes
- [X] I considered backward compatibility and migration impact
